### PR TITLE
Apply minor fixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,12 +16,12 @@ let package = Package(
     dependencies: [],
     targets: [
         .target(
-            name: "TransifexNativeObjCRuntime",
-            dependencies: []
+            name: "TransifexNativeObjCRuntime"
         ),
         .target(
             name: "TransifexNative",
             dependencies: [ "TransifexNativeObjCRuntime" ],
+            exclude: [ "TXNativeExtensions.swift" ],
             resources: [
                 .copy("Localizable.stringsdict")
             ]

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ add this file to your project.
     ]];
 
     [TxNative initializeWithLocales:localeState
-                              token:@"token"
-                             secret:@"secret"
+                              token:@"<transifex_token>"
+                             secret:@"<transifex_secret>"
                             cdsHost:@"https://cds.svc.transifex.net/"
                               cache:[MemoryCache new]
                       missingPolicy:compositePolicy


### PR DESCRIPTION
* Updates README regarding the Transifex token and secret usage in ObjC
apps.
* Removes `TXNativeExtensions.swift` file from `TransifexNative` target
to silence the import warning.