### PR TITLE
Locale related fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 # Transifex Native iOS SDK
 
-Transifex Native iOS SDK is a collection of tools to easily localize your iOS applications using [Transifex Native](https://www.transifex.com/native/). The can fetch translations over the air (OTA) to your apps. It supports apps built both on Objective-C and Swift.
+Transifex Native iOS SDK is a collection of tools to easily localize your iOS applications 
+using [Transifex Native](https://www.transifex.com/native/). The tool can fetch translations 
+over the air (OTA) to your apps. It supports apps built both on Objective-C and Swift.
 
-The package is built using Swift 5.3, as it currently requires a bundled resource to be present in the package (which was introduced on version 5.3). An update that will require a lower Swift version is currently WIP.
+The package is built using Swift 5.3, as it currently requires a bundled resource to be 
+present in the package (which was introduced on version 5.3). An update that will require 
+a lower Swift version is currently WIP.
 
 Learn more about [Transifex Native](https://docs.transifex.com/transifex-native-sdk-overview/introduction).
 
 ## Usage
 
-The SDK allows you to keep using the same localization hooks that the iOS framework provides, such as 
-`NSLocalizedString`, `String.localizedStringWithFormat(format:...)`, etc, but at the same time 
-taking advantage of the features that Transifex Native offers, such as OTA translations.
+The SDK allows you to keep using the same localization hooks that the iOS framework 
+provides, such as `NSLocalizedString`, 
+`String.localizedStringWithFormat(format:...)`, etc, but at the same time taking 
+advantage of the features that Transifex Native offers, such as OTA translations.
 
-Keep in mind that in the sample code below you will have to replace `<transifex_token>` and `<transifex_secret>` 
-with the actual token and secret that are associated with your Transifex project and resource. 
+Keep in mind that in the sample code below you will have to replace 
+`<transifex_token>` and `<transifex_secret>` with the actual token and secret that 
+are associated with your Transifex project and resource. 
 
 ### SDK configuration (Swift)
 
@@ -26,7 +32,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         TxNative.initialize(
             locales: LocaleState(sourceLocale: "en", 
-                                 appLocales: ["el", "fr"]),
+                                 appLocales: ["en", "el", "fr"]),
             token: "<transifex_token>",
             secret: "<transifex_secret>",
             cdsHost: "https://cds.svc.transifex.net/",
@@ -61,7 +67,8 @@ add this file to your project.
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     LocaleState *localeState = [[LocaleState alloc] initWithSourceLocale:@"en"
                                                               appLocales:@[
-                                                                  @"el" ,
+                                                                  @"en",
+                                                                  @"el",
                                                                   @"fr"
                                                               ]
                                                    currentLocaleProvider:nil];
@@ -89,28 +96,41 @@ add this file to your project.
 ```
 
 ### Fetching translations
-As soon as `fetchTranslations` is called, the SDK will attempt to download the translations for all locales
-that are defined in the initialization of `TxNative`. 
 
-For the moment, the translations are stored only in memory and are available for the current app session.
-In later versions of the SDK, the translations will also be stored on the device and will be available for subsequent
-app sessions.
+As soon as `fetchTranslations` is called, the SDK will attempt to download the 
+translations for all locales - except for the source locale - that are defined in the 
+initialization of `TxNative`. 
+
+For the moment, the translations are stored only in memory and are available for the 
+current app session. In later versions of the SDK, the translations will also be stored on 
+the device and will be available for subsequent app sessions.
 
 ### Pushing source content
-In order to push the source translations to CDS, you will first need to prepare an array of `TxSourceString` objects
-that will hold all the necessary information needed for CDS. You can refer to the `TxSourceString` class for more
-information, or you can look at the list below:
 
-* `key` (required): The key of the source string, generated via the public `generateKey()` method.
+In order to push the source translations to CDS, you will first need to prepare an array of 
+`TxSourceString` objects that will hold all the necessary information needed for CDS. 
+You can refer to the `TxSourceString` class for more information, or you can look at the 
+list below:
+
+* `key` (required): The key of the source string, generated via the public `generateKey()` 
+method.
 * `sourceString` (required): The actual source string.
-* `developerComment` (optional): An optional comment provided by the developer to assist the translators.
-* `occurrencies` (required): A list of relative paths where the source string is located in the project.
+* `developerComment` (optional): An optional comment provided by the developer to
+assist the translators.
+* `occurrencies` (required): A list of relative paths where the source string is located in 
+the project.
 
-After building an array of `TxSourceString` objects, use the `pushTranslations` method to push them to CDS. You can optionally set the `purge` argument to `true` (defaults to `false`) to replace the entire resource content. The completion handler can be used to get notified asynchronously whether the request was successful or not.
+After building an array of `TxSourceString` objects, use the `pushTranslations` method 
+to push them to CDS. You can optionally set the `purge` argument to `true` (defaults to 
+`false`) to replace the entire resource content. The completion handler can be used to 
+get notified asynchronously whether the request was successful or not.
 
 ### Invalidating CDS cache
-The cache of CDS has a TTL of 30 minutes. If you update some translations on Transifex and you need
-to see them on your app immediately, you need to make an HTTP request to the [invalidation endpoint](https://github.com/transifex/transifex-delivery/#invalidate-cache) of CDS.
+
+The cache of CDS has a TTL of 30 minutes. If you update some translations on Transifex 
+and you need to see them on your app immediately, you need to make an HTTP request 
+to the [invalidation endpoint](https://github.com/transifex/transifex-delivery/#invalidate-cache) 
+of CDS.
 
 ## License
 Licensed under Apache License 2.0, see [LICENSE](LICENSE) file.

--- a/Sources/TransifexNative/Core.swift
+++ b/Sources/TransifexNative/Core.swift
@@ -33,8 +33,6 @@ public class NativeCore : TranslationProvider {
     
     /// Create an instance of the core framework class.
     ///
-    /// Also warms up the cache by fetching the translations from the CDS.
-    ///
     /// - Parameters:
     ///   - locales: a list of locale codes for the languages configured in the application
     ///   - token: the API token to use for connecting to the CDS
@@ -56,7 +54,7 @@ public class NativeCore : TranslationProvider {
     ) {
         self.locales = locales
         self.cdsHandler = CDSHandler(
-            localeCodes: self.locales.appLocales,
+            localeCodes: self.locales.translatedLocales,
             token: token,
             secret: secret,
             cdsHost: cdsHost

--- a/Tests/TransifexNativeTests/TransifexNativeTests.swift
+++ b/Tests/TransifexNativeTests/TransifexNativeTests.swift
@@ -80,7 +80,7 @@ class URLSessionMock: URLSession {
     }
 }
 
-class MockLocaleProvider : CurrentLocaleProvider {
+class MockLocaleProvider : TXCurrentLocaleProvider {
     private var mockLocaleCode : String
     
     init(_ mockLocaleCode: String) {


### PR DESCRIPTION
This pull request includes fixes regarding the `CurrentLocaleProvider` protocol (now renamed to `TXCurrentLocaleProvider`) and the `UserDefaultsLocaleProvider` (now renamed to `TXPreferredLocaleProvider`) that now uses the `NSLocale.autoupdatingCurrent` property.

Also address a number of small issues regarding the documentation of the `LocaleState` class and introduces a new property (`translatedLocales`) that's used by the `CDSHandler` when fetching the translations from the server.