### PR TITLE
Improve pull logic, refactor cache

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,20 @@
+name: Swift
+
+on:
+  push:
+    branches: [ devel ]
+  pull_request:
+    branches: [ devel ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v
+

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ After the cached entries have updated the memory cache, the cache is ready to be
 
 Whenever new translations are fetched from the server using the `fetchTranslations()` 
 method, the standard cache is updated and those translations are stored as-is in the file 
-system, in the same cache fileused by the aforementioned second cache provider so that 
+system, in the same cache file used by the aforementioned second cache provider so that 
 they are available on the next app launch.
 
 #### Alternative cache strategy

--- a/README.md
+++ b/README.md
@@ -125,6 +125,83 @@ to push them to CDS. You can optionally set the `purge` argument to `true` (defa
 `false`) to replace the entire resource content. The completion handler can be used to 
 get notified asynchronously whether the request was successful or not.
 
+### Standard Cache
+
+The default cache strategy used by the SDK, if no other cache is provided by the 
+developer, is the `TXStandardCache`. The standard cache operates by making use of the 
+publicly exposed classes and protocols from the Cache.swift file of the SDK, so it's easy 
+to construct another cache strategy if that's desired.
+
+The standard cache is initialized with a memory cache (`TXMemoryCache`) that manages all 
+cached entries in memory. After the memory cache gets initialized, it tries to look up if 
+there are any already stored cache files in the file system using the 
+`TXDiskCacheProvider` class: 
+
+* The first cache provider is the bundle cache provider, that looks up for an already 
+created cache file in the main application bundle of the app that may have been offered 
+by the developer.
+* The second cache provider looks up for a cache file in the application sandbox directory 
+(using the optional app group identifier argument if provided), in case the app had  already 
+downloaded the translations from the server from a previous launch.
+
+Those two providers are used to initialize the memory cache using an override policy 
+(`TXCacheOverridePolicy`) which is optionally provided by the developer and defaults to 
+the `overrideAll` value. 
+
+After the cached entries have updated the memory cache, the cache is ready to be used.
+
+Whenever new translations are fetched from the server using the `fetchTranslations()` 
+method, the standard cache is updated and those translations are stored as-is in the file 
+system, in the same cache fileused by the aforementioned second cache provider so that 
+they are available on the next app launch.
+
+#### Alternative cache strategy
+
+You might want to update the internal memory cache as soon as the newly downloaded 
+translations are available and always override all entries, so that the override policy can 
+also be ommited. 
+
+In order to achieve that, you can create a new  `TXDecoratorCache` subclass that has a 
+similar initializer as the `TXStandardCache` one, with the exception of the 
+`TXReadonlyCacheDecorator` and the `TXStringOverrideFilterCache` initializers:
+ 
+ ```swift
+ public init(groupIdentifier: String? = nil) {
+     // ...Same as TXStandardCache...
+
+     let cache = TXFileOutputCacheDecorator(
+         fileURL: downloadURL,
+         internalCache: TXProviderBasedCache(
+             providers: providers,
+             internalCache: TXMemoryCache()
+         )
+     )
+     
+     super.init(internalCache: cache)
+ }
+ ```
+ 
+ This way, whenever the cache is updated with the new translations from the 
+ `fetchTranslations()` method, the `update()` call will propagate to the internal
+ `TXMemoryCache` and update all of its entries.
+ 
+### Application Extensions
+
+In order to add the SDK to an application extension target, be sure to include the 
+`TransifexNative` library in the 'Frameworks and Libraries' section of the General 
+settings of the application extension you are working on.
+
+Furthermore, in case Xcode produces a "No such module 'TransifexNative'" error on the 
+`import TransifexNative` statements of the extension files, be sure to add the 
+`$(SRCROOT)` path in the 'Framework Search Paths' setting under the Build Settings of the 
+application extension target.
+
+In order to make the Transifex Native SDK cache file visible by both the extension and the 
+main application targets, you would need to enable the App Groups capability in both the 
+main application and the extension targets and use an existing or create a new app group 
+identifier. Then, you would need to initialize the Transifex Native SDK with the 
+`TXStandardCache` passing that app group identifier as the `groupIdentifier` argument.
+
 ### Invalidating CDS cache
 
 The cache of CDS has a TTL of 30 minutes. If you update some translations on Transifex 

--- a/Sources/TransifexNative/Cache.swift
+++ b/Sources/TransifexNative/Cache.swift
@@ -8,12 +8,13 @@
 
 import Foundation
 
-public typealias StringInfo = [String: String]
-public typealias LocaleStrings = [String: StringInfo]
+public typealias TXStringInfo = [String: String]
+public typealias TXLocaleStrings = [String: TXStringInfo]
+public typealias TXTranslations = [String: TXLocaleStrings]
 
-/// A protocol for classes that act as cache for translations
+/// A protocol for classes that act as cache for translations.
 @objc
-public protocol Cache {
+public protocol TXCache {
     
     /// Get the translation for a certain key and locale code pair.
     ///
@@ -42,35 +43,303 @@ public protocol Cache {
     ///
     /// - Parameters:
     ///   - translations: The dictionary structure of translations
-    func update(translations: [String: LocaleStrings])
+    ///   - replaceEntries: whether the passed translations should replace all of the existing
+    ///   entries or leave the entries not included in the translations argument untouched.
+    func update(translations: TXTranslations,
+                replaceEntries: Bool)
 }
 
-/// A cache that holds translations in memory
-public final class MemoryCache : NSObject {
-    
-    /// Serial dispatch queue that ensures that cache will only be updated / read by one thread
-    let cacheQueue = DispatchQueue(label: "com.transifex.native.memorycache")
-    
-    var translationsByLocale: [String: LocaleStrings]
+/// A protocol for classes that act as providers of cached translations (e.g. extracting them from a file)
+@objc
+public protocol TXCacheProvider {
+    /// Returns the translations from the current cache provider.
+    func getTranslations() -> TXTranslations?
+}
+
+/// Cache provider that loads translations from disk
+@objc
+public final class TXDiskCacheProvider: NSObject, TXCacheProvider {
+    /// The translations extracted from disk after initialization.
+    public let translations: TXTranslations?
     
     @objc
-    public override init() {
-        self.translationsByLocale = [:]
+    public init(fileURL: URL) {
+        self.translations = TXDiskCacheProvider.load(from: fileURL)
+    }
+    
+    /// Loads the translations from a file url, returns nil in case of an error
+    /// - Parameter fileURL: The url of the file that contains the translations
+    /// - Returns: The translations or nil if there was an error
+    private static func load(from fileURL: URL) -> TXTranslations? {
+        var fileData: Data?
+    
+        do {
+            fileData = try Data(contentsOf: fileURL)
+        }
+        catch {
+            print("\(#function) fileURL: \(fileURL) Data error: \(error)")
+        }
+        
+        guard let data = fileData else {
+            return nil
+        }
+        
+        var storedTranslations: TXTranslations?
+
+        do {
+            storedTranslations = try JSONDecoder().decode(TXTranslations.self,
+                                                          from: data)
+        }
+        catch {
+            print("\(#function) fileURL: \(fileURL) Decode Error: \(error)")
+            return nil
+        }
+        
+        return storedTranslations
+    }
+
+    public func getTranslations() -> TXTranslations? {
+        return translations
     }
 }
 
-extension MemoryCache : Cache {
-    public func update(translations: [String: LocaleStrings]) {
-        cacheQueue.sync {
-            for (localeCode, localeTranslations) in translations {
-                translationsByLocale[localeCode] = localeTranslations
+/// Composite class that accepts a number of cache providers, an internal cache and whether the providers
+/// should replace the entries of the cache or not. The providers are then used to update the internal class
+/// in the order they are added in the providers list.
+@objc
+public final class TXProviderBasedCache: NSObject {
+    let memoryCache: TXCache
+    
+    @objc
+    public init(providers: [TXCacheProvider],
+                memoryCache: TXCache,
+                replaceEntries: Bool = false) {
+        self.memoryCache = memoryCache
+        for provider in providers {
+            if let providerTranslations = provider.getTranslations() {
+                self.memoryCache.update(translations: providerTranslations,
+                                        replaceEntries: replaceEntries)
+            }
+        }
+        super.init()
+    }
+}
+
+extension TXProviderBasedCache: TXCache {
+    public func get(key: String, localeCode: String) -> String? {
+        return memoryCache.get(key: key, localeCode: localeCode)
+    }
+    
+    /// Provider based cache doesn't update its internal cache after being initialiazed, so the update
+    /// method of the TXCache protocol is a no-op.
+    
+    public func update(translations: TXTranslations,
+                       replaceEntries: Bool) {
+        /// No-op
+    }
+}
+
+@objc
+public final class TXDefaultCache: NSObject {
+    private static let DOWNLOADED_FOLDER_NAME = "txnative"
+    
+    /// Dispatch queue that ensures that the downloaded strings are written to a file in a serial fashion.
+    let cacheQueue = DispatchQueue(label: "com.transifex.native.memorycache")
+    
+    private let internalCache: TXCache
+    private let groupIdentifier: String?
+    
+    @objc
+    public init(groupIdentifier: String? = nil,
+                replaceEntries: Bool = false) {
+        var providers: [TXCacheProvider] = []
+        
+        if let bundledURL = TXDefaultCache.bundledTranslationsURL() {
+            providers.append(TXDiskCacheProvider(fileURL: bundledURL))
+        }
+        
+        if let downloadedURL = TXDefaultCache.downloadedTranslationsURL(groupIdentifier: groupIdentifier) {
+            providers.append(TXDiskCacheProvider(fileURL: downloadedURL))
+        }
+    
+        self.groupIdentifier = groupIdentifier
+        self.internalCache = TXProviderBasedCache(providers: providers,
+                                                  memoryCache: TXMemoryCache(),
+                                                  replaceEntries: replaceEntries)
+    }
+    
+    /// - Returns: The URL of the translations file in the main bundle of the app
+    private static func bundledTranslationsURL() -> URL? {
+        let resourceComps = TxNative.STRINGS_FILENAME.split(separator: ".")
+        
+        guard resourceComps.count == 2 else {
+            return nil
+        }
+        
+        let resourceName = String(resourceComps[0])
+        let resourceExtension = String(resourceComps[1])
+        
+        guard let url = Bundle.main.url(forResource: resourceName,
+                                        withExtension: resourceExtension) else {
+            return nil
+        }
+
+        return url
+    }
+    
+    /// - Parameters:
+    ///   - groupIdentifier: The group identifier of the app group of the app (if available)
+    ///   - includeFilename: Whether the final url will include the translations filename or just its folder
+    /// - Returns: The URL of the translations file (or its folder if includeFilename=false) in the caches
+    /// or the app group directory of the app.
+    ///
+    /// Pattern:
+    /// `[caches or app group directory]/DOWNLOADED_FOLDER_NAME/{STRINGS_FILENAME}`
+    private static func downloadedTranslationsURL(groupIdentifier: String?,
+                                                  includeFilename: Bool = true) -> URL? {
+        let fileManager = FileManager.default
+
+        var baseURL: URL? = nil
+        
+        if let groupIdentifier = groupIdentifier,
+           let groupURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier) {
+            baseURL = groupURL
+        }
+        else {
+            let cacheURLs = fileManager.urls(for: .cachesDirectory,
+                                             in: .userDomainMask)
+            
+            if cacheURLs.count > 0 {
+                baseURL = cacheURLs[0]
+            }
+        }
+        
+        guard let folderURL = baseURL?.appendingPathComponent(TXDefaultCache.DOWNLOADED_FOLDER_NAME) else {
+            return nil
+        }
+        
+        if !includeFilename {
+            return folderURL
+        }
+        
+        return folderURL.appendingPathComponent(TxNative.STRINGS_FILENAME)
+    }
+    
+    enum StoringErrors: Error {
+        case urlNotFound
+        case encodingFailed
+    }
+    
+    /// Serializes passed translations and stores them in the `TxNative.STRINGS_FILENAME` file
+    /// in the caches directory of the app.
+    ///
+    /// - Parameter translations: The passed translations
+    /// - Throws: The error that may occur during serialization, directory creation or file writing.
+    private func storeTranslations(translations: TXTranslations) throws {
+        guard let folderURL = TXDefaultCache.downloadedTranslationsURL(groupIdentifier: groupIdentifier,
+                                                                       includeFilename: false) else {
+            throw StoringErrors.urlNotFound
+        }
+        
+        do {
+            try FileManager.default.createDirectory(at: folderURL,
+                                                    withIntermediateDirectories: true,
+                                                    attributes: nil)
+        }
+        
+        var jsonData: Data?
+        
+        do {
+            jsonData = try JSONEncoder().encode(translations)
+        }
+        
+        guard let serializedData = jsonData,
+              let serializedTranslations = String(data: serializedData,
+                                                  encoding: .utf8) else {
+            throw StoringErrors.encodingFailed
+        }
+        
+        let outputFileURL = folderURL.appendingPathComponent(TxNative.STRINGS_FILENAME)
+        
+        do {
+            try serializedTranslations.write(to: outputFileURL,
+                                             atomically: true,
+                                             encoding: .utf8)
+        }
+    }
+}
+
+extension TXDefaultCache: TXCache {
+    public func get(key: String, localeCode: String) -> String? {
+        /// The get() method here will call TXProviderBasedCache.get() which in turn is going to call
+        /// TXMemoryCache.get().
+        return internalCache.get(key: key, localeCode: localeCode)
+    }
+    
+    public func update(translations: TXTranslations,
+                       replaceEntries: Bool) {
+        /// When update is called in the default cache, we ignore the replaceEntries flag as we always
+        /// want to store the passed translations in a file in the downloaded translations url.
+        cacheQueue.async {
+            do {
+                try self.storeTranslations(translations: translations)
+            }
+            catch {
+                print("\(#function) Error: \(error)")
             }
         }
     }
+}
+
+
+/// A simple in-memory cache that updates its contents and returns the proper translation.
+///
+/// This class is not thread-safe, so be sure that you are calling the update / get methods from a serial queue.
+@objc
+public final class TXMemoryCache: NSObject {
+    private static let STRING_KEY = "string"
     
+    var translationsByLocale: TXTranslations = [:]
+}
+
+extension TXMemoryCache: TXCache {
     public func get(key: String, localeCode: String) -> String? {
-        cacheQueue.sync {
-            return translationsByLocale[localeCode]?[key]?["string"]
+        return translationsByLocale[localeCode]?[key]?[TXMemoryCache.STRING_KEY]
+    }
+    
+    public func update(translations: TXTranslations,
+                       replaceEntries: Bool) {
+        /// If the replaceEntries is true, we replace the whole cache with the translations of the provided
+        /// provider.
+        if replaceEntries {
+            translationsByLocale = translations
         }
+        else {
+            /// Otherwise we check whether each key in each locale of the provider exists in cache and
+            /// we update it, while leaving the rest of the keys and locales untouched.
+            for (localeCode, localeTranslations) in translations {
+                if translationsByLocale[localeCode] != nil {
+                    for (stringKey, translation) in localeTranslations {
+                        translationsByLocale[localeCode]?[stringKey] = translation
+                    }
+                } else {
+                    translationsByLocale[localeCode] = localeTranslations
+                }
+            }
+        }
+    }
+}
+
+/// A no-op cache that doesn't support storing the values in-memory. Useful when the library needs to be
+/// initialized without a cache (e.g. for the CLI tool).
+@objc
+public final class TXNoOpCache: NSObject, TXCache {
+    public func get(key: String, localeCode: String) -> String? {
+        return nil
+    }
+    
+    public func update(translations: TXTranslations,
+                       replaceEntries: Bool) {
+        /// No-op
     }
 }

--- a/Sources/TransifexNative/Core.swift
+++ b/Sources/TransifexNative/Core.swift
@@ -60,7 +60,7 @@ class NativeCore : TranslationProvider {
             secret: secret,
             cdsHost: cdsHost
         )
-        self.cache = cache ?? TXDefaultCache()
+        self.cache = cache ?? TXStandardCache()
         self.missingPolicy = missingPolicy ?? SourceStringPolicy()
         self.errorPolicy = errorPolicy ?? RenderedSourceErrorPolicy()
         self.renderingStrategy = renderingStrategy
@@ -76,8 +76,7 @@ class NativeCore : TranslationProvider {
                            completionHandler: PullCompletionHandler? = nil) {
         cdsHandler.fetchTranslations(localeCode: localeCode) { (translations, errors) in
             if errors.count == 0 {
-                self.cache.update(translations: translations,
-                                  replaceEntries: true)
+                self.cache.update(translations: translations)
             }
             else {
                 print("\(#function) Errors: \(errors)")

--- a/Tests/TransifexNativeTests/TransifexNativeTests.swift
+++ b/Tests/TransifexNativeTests/TransifexNativeTests.swift
@@ -92,6 +92,18 @@ class MockLocaleProvider : TXCurrentLocaleProvider {
     }
 }
 
+class MockCacheProvider : TXCacheProvider {
+    let translations: TXTranslations?
+    
+    init(translations: TXTranslations) {
+        self.translations = translations
+    }
+    
+    func getTranslations() -> TXTranslations? {
+        return translations
+    }
+}
+
 final class TransifexNativeTests: XCTestCase {
     func testDuplicateLocaleFiltering() {
         let duplicateLocales = [ "en", "fr", "en" ]
@@ -179,7 +191,7 @@ final class TransifexNativeTests: XCTestCase {
     
     func testFetchTranslations() {
         let expectation = self.expectation(description: "Waiting for translations to be fetched")
-        var translationsResult : [String: LocaleStrings]? = nil
+        var translationsResult : TXTranslations? = nil
         
         let mockResponseData = "{\"data\":{\"testkey1\":{\"string\":\"test string 1\"},\"testkey2\":{\"string\":\"test string 2\"}}}".data(using: .utf8)
         
@@ -194,7 +206,7 @@ final class TransifexNativeTests: XCTestCase {
                                     token: "test_token",
                                     session: urlSession)
         
-        cdsHandler.fetchTranslations { (translations) in
+        cdsHandler.fetchTranslations { (translations, errors) in
             translationsResult = translations
             expectation.fulfill()
         }
@@ -212,7 +224,7 @@ final class TransifexNativeTests: XCTestCase {
     
     func testFetchTranslationsNotReady() {
         let expectation = self.expectation(description: "Waiting for translations to be fetched")
-        var translationsResult : [String: LocaleStrings]? = nil
+        var translationsResult : TXTranslations? = nil
         
         let mockResponseData = "{\"data\":{\"testkey1\":{\"string\":\"test string 1\"},\"testkey2\":{\"string\":\"test string 2\"}}}".data(using: .utf8)
         
@@ -234,7 +246,7 @@ final class TransifexNativeTests: XCTestCase {
                                     token: "test_token",
                                     session: urlSession)
         
-        cdsHandler.fetchTranslations { (translations) in
+        cdsHandler.fetchTranslations { (translations, errors) in
             translationsResult = translations
             expectation.fulfill()
         }
@@ -279,6 +291,58 @@ final class TransifexNativeTests: XCTestCase {
             XCTAssertTrue(pushResult)
         }
     }
+    
+    func testProviderBasedCacheDontReplace() {
+        let firstProviderTranslations: TXTranslations = [
+            "en": [
+                "key1": [ "string": "localized string1" ]
+            ]
+        ]
+        let secondProviderTranslations: TXTranslations = [
+            "en": [
+                "key2": [ "string": "localized string1" ]
+            ]
+        ]
+        
+        let firstProvider = MockCacheProvider(translations: firstProviderTranslations)
+        let secondProvider = MockCacheProvider(translations: secondProviderTranslations)
+        
+        let testProviderBasedCache = TXProviderBasedCache(providers: [
+            firstProvider,
+            secondProvider
+        ],
+        memoryCache: TXMemoryCache(),
+        replaceEntries: false)
+        
+        XCTAssertNotNil(testProviderBasedCache.get(key: "key1", localeCode: "en"))
+        XCTAssertNotNil(testProviderBasedCache.get(key: "key2", localeCode: "en"))
+    }
+    
+    func testProviderBasedCacheReplace() {
+        let firstProviderTranslations: TXTranslations = [
+            "en": [
+                "key1": [ "string": "localized string1" ]
+            ]
+        ]
+        let secondProviderTranslations: TXTranslations = [
+            "en": [
+                "key2": [ "string": "localized string1" ]
+            ]
+        ]
+        
+        let firstProvider = MockCacheProvider(translations: firstProviderTranslations)
+        let secondProvider = MockCacheProvider(translations: secondProviderTranslations)
+        
+        let testProviderBasedCache = TXProviderBasedCache(providers: [
+            firstProvider,
+            secondProvider
+        ],
+        memoryCache: TXMemoryCache(),
+        replaceEntries: true)
+        
+        XCTAssertNil(testProviderBasedCache.get(key: "key1", localeCode: "en"))
+        XCTAssertNotNil(testProviderBasedCache.get(key: "key2", localeCode: "en"))
+    }
 
     static var allTests = [
         ("testDuplicateLocaleFiltering", testDuplicateLocaleFiltering),
@@ -290,5 +354,7 @@ final class TransifexNativeTests: XCTestCase {
         ("testFetchTranslationsNotReady", testFetchTranslationsNotReady),
         ("testExtractICUPlurals", testExtractICUPlurals),
         ("testPushTranslations", testPushTranslations),
+        ("testProviderBasedCacheDontReplace", testProviderBasedCacheDontReplace),
+        ("testProviderBasedCacheReplace", testProviderBasedCacheReplace),
     ]
 }

--- a/Tests/TransifexNativeTests/TransifexNativeTests.swift
+++ b/Tests/TransifexNativeTests/TransifexNativeTests.swift
@@ -397,7 +397,7 @@ final class TransifexNativeTests: XCTestCase {
         
         XCTAssertNotNil(cache.get(key: "key1", localeCode: "en"))
         XCTAssertTrue(cache.get(key: "key1", localeCode: "en") == "localized string 1")
-        XCTAssertNil(cache.get(key: "key2", localeCode: "en"))
+        XCTAssertNotNil(cache.get(key: "key2", localeCode: "en"))
     }
 
     static var allTests = [


### PR DESCRIPTION
The `fetchTranslations` method now offers a completion handler so that
the caller is notified when the downloading of the translations is
complete.

The completion block of that method now also reports any errors that
may have been encountered during the download operation so that the
caller can decide how the resulting translations should be treated.

`LocaleStrings` and all of the depended type aliases have now a `TX`
prefix to avoid any unwanted naming collisions.

Caching logic has been improved: If an object that conforms to the `TXCache`
protocol (which has also been renamed) isn't provided during the
`TxNative` initialization, then the internal `MemoryCache` is used,
which during its initialization looks up both in the main app bundle and
in the application directory to find any already generated or downloaded
translation files. If those files are found, the memory cache is updated
accordingly.

Also, when the new translations are fetched from CDS, the downloaded file
is either generated or replaced by those new translations.

The developers can now choose whether cache is used at all by using the
`useCache` argument of the `TxNative` initializer, which defaults to true.

Also, for applications that make use of several different targets (e.g.
extensions), the `TxNative` offers a new argument (`groupIdentifier`) so
that the downloaded translations are stored in the application group
directory in order for all of the targets to be able to have access to
them.