### PR TITLE
Refactor cache policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,10 @@
 *February 24, 2021*
 
 - Fixed preferred locale provider
+
+## Transifex iOS SDK 0.1.2
+
+*March 17, 2021*
+
+- Applies minor refactors in cache logic
+- Renames override policy to update policy and improves documentation.

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ get notified asynchronously whether the request was successful or not.
 ### Standard Cache
 
 The default cache strategy used by the SDK, if no other cache is provided by the 
-developer, is the `TXStandardCache`. The standard cache operates by making use of the 
-publicly exposed classes and protocols from the Cache.swift file of the SDK, so it's easy 
-to construct another cache strategy if that's desired.
+developer, is the `TXStandardCache.getCache()`. The standard cache operates 
+by making use of the publicly exposed classes and protocols from the Cache.swift file of the 
+SDK, so it's easy to construct another cache strategy if that's desired.
 
 The standard cache is initialized with a memory cache (`TXMemoryCache`) that manages all 
 cached entries in memory. After the memory cache gets initialized, it tries to look up if 
@@ -196,9 +196,9 @@ by the developer.
 (using the optional app group identifier argument if provided), in case the app had  already 
 downloaded the translations from the server from a previous launch.
 
-Those two providers are used to initialize the memory cache using an override policy 
-(`TXCacheOverridePolicy`) which is optionally provided by the developer and defaults to 
-the `overrideAll` value. 
+Those two providers are used to initialize the memory cache using an update policy 
+(`TXCacheUpdatePolicy`) which is optionally provided by the developer and defaults to 
+the `replaceAll` value. 
 
 After the cached entries have updated the memory cache, the cache is ready to be used.
 
@@ -210,28 +210,21 @@ they are available on the next app launch.
 #### Alternative cache strategy
 
 You might want to update the internal memory cache as soon as the newly downloaded 
-translations are available and always override all entries, so that the override policy can 
+translations are available and always update all entries, so that the update policy can 
 also be ommited. 
 
-In order to achieve that, you can create a new  `TXDecoratorCache` subclass that has a 
-similar initializer as the `TXStandardCache` one, with the exception of the 
-`TXReadonlyCacheDecorator` and the `TXStringOverrideFilterCache` initializers:
- 
- ```swift
- public init(groupIdentifier: String? = nil) {
-     // ...Same as TXStandardCache...
+In order to achieve that, you can create a new  `TXDecoratorCache` subclass or create a 
+method that returns a `TXCache` instance, just like in the `TXStandardCache.getCache()`
+case.
 
-     let cache = TXFileOutputCacheDecorator(
-         fileURL: downloadURL,
-         internalCache: TXProviderBasedCache(
-             providers: providers,
-             internalCache: TXMemoryCache()
-         )
-     )
-     
-     super.init(internalCache: cache)
- }
- ```
+```swift
+func getCustomCache() -> TXCache {
+    return TXFileOutputCacheDecorator(
+        fileURL: ...,
+        internalCache: ...
+    )
+}
+```
  
  This way, whenever the cache is updated with the new translations from the 
  `fetchTranslations()` method, the `update()` call will propagate to the internal

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -129,7 +129,7 @@ class NativeCore : TranslationProvider {
             cdsHost: cdsHost,
             session: session
         )
-        self.cache = cache ?? TXStandardCache()
+        self.cache = cache ?? TXStandardCache.getCache()
         self.missingPolicy = missingPolicy ?? TXSourceStringPolicy()
         self.errorPolicy = errorPolicy ?? TXRenderedSourceErrorPolicy()
         self.renderingStrategy = renderingStrategy
@@ -194,7 +194,7 @@ class NativeCore : TranslationProvider {
         /// If this call call originates from a `localizedStringWithFormat` swizzled method, it will
         /// contain the extra arguments. In that case the first argument of those methods (format) would
         /// have already been resolved by a `NSLocalizedString()` call, so we should not perform
-        /// a second lookup on the cache, we can proceed by directly rendering the strict and let the
+        /// a second lookup on the cache, we can proceed by directly rendering the string and let the
         /// `render()` method extract the ICU plurals.
         if params[Swizzler.PARAM_ARGUMENTS_KEY] != nil {
             return render(sourceString: sourceString,
@@ -240,7 +240,7 @@ class NativeCore : TranslationProvider {
                                     context: context)
             translationTemplate = cache.get(key: key,
                                             localeCode: localeToRender)
-            if translationTemplate == nil {
+            if !String.containsTranslation(translationTemplate) {
                 let bypassedString = self.bypassLocalizer.get(sourceString: sourceString,
                                                               params: params)
                 
@@ -300,7 +300,7 @@ Error rendering source string '\(sourceString)' with string to render '\(stringT
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "0.1.1"
+    internal static let version = "0.1.2"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -301,114 +301,123 @@ final class TransifexTests: XCTestCase {
         }
     }
     
-    func testOverrideFilterCacheAll() {
-        let firstProviderTranslations: TXTranslations = [
+    func testReplaceAllPolicy() {
+        let existingTranslations: TXTranslations = [
             "en": [
-                "key1": [ "string": "localized string 1" ]
+                "a": [ "string": "a" ],
+                "b": [ "string": "b" ],
+                "c": [ "string": "c" ],
+                "d": [ "string": "" ],
+                "e": [ "string": "" ]
             ]
         ]
-        let secondProviderTranslations: TXTranslations = [
-            "en": [
-                "key2": [ "string": "localized string 2" ],
-                "key3": [ "string": "" ]
-            ]
-        ]
-        
-        let firstProvider = MockCacheProvider(translations: firstProviderTranslations)
-        let secondProvider = MockCacheProvider(translations: secondProviderTranslations)
-        
-        let cache = TXProviderBasedCache(
-            providers: [
-                firstProvider,
-                secondProvider
-            ],
-            internalCache: TXStringOverrideFilterCache(
-                policy: .overrideAll,
-                internalCache: TXMemoryCache()
-            )
-        )
-        
-        XCTAssertNil(cache.get(key: "key1", localeCode: "en"))
-        XCTAssertNotNil(cache.get(key: "key2", localeCode: "en"))
-        XCTAssertNil(cache.get(key: "key3", localeCode: "en"))
-    }
-    
-    func testOverrideFilterCacheUntranslated() {
-        let firstProviderTranslations: TXTranslations = [
-            "en": [
-                "key1": [ "string": "localized string 1" ]
-            ]
-        ]
-        let secondProviderTranslations: TXTranslations = [
-            "en": [
-                "key2": [ "string": "localized string 2" ],
-                "key3": [ "string": "" ]
-            ]
-        ]
-        
-        let firstProvider = MockCacheProvider(translations: firstProviderTranslations)
-        let secondProvider = MockCacheProvider(translations: secondProviderTranslations)
         
         let memoryCache =  TXMemoryCache()
-        memoryCache.update(translations: [
-            "en": [
-                "key1": [ "string": "old localized string 1"]
-            ]
-        ])
+        memoryCache.update(translations: existingTranslations)
         
+        let newTranslations: TXTranslations = [
+            "en": [
+                "b": [ "string": "B" ],
+                "c": [ "string": "" ],
+                "e": [ "string": "E" ],
+                "f": [ "string": "F" ],
+                "g": [ "string": "" ]
+            ]
+        ]
+        let provider = MockCacheProvider(translations: newTranslations)
+
         let cache = TXProviderBasedCache(
-            providers: [
-                firstProvider,
-                secondProvider
-            ],
-            internalCache: TXStringOverrideFilterCache(
-                policy: .overrideUntranslatedOnly,
+            providers: [ provider ],
+            internalCache: TXStringUpdateFilterCache(
+                policy: .replaceAll,
                 internalCache: memoryCache
             )
         )
         
-        XCTAssertNotNil(cache.get(key: "key1", localeCode: "en"))
-        XCTAssertTrue(cache.get(key: "key1", localeCode: "en") == "old localized string 1")
-        XCTAssertNotNil(cache.get(key: "key2", localeCode: "en"))
-        XCTAssertNil(cache.get(key: "key3", localeCode: "en"))
+        XCTAssertNil(cache.get(key: "a", localeCode: "en"))
+        XCTAssertEqual(cache.get(key: "b", localeCode: "en"), "B")
+        XCTAssertEqual(cache.get(key: "c", localeCode: "en"), "")
+        XCTAssertNil(cache.get(key: "d", localeCode: "en"))
+        XCTAssertEqual(cache.get(key: "e", localeCode: "en"), "E")
+        XCTAssertEqual(cache.get(key: "f", localeCode: "en"), "F")
+        XCTAssertEqual(cache.get(key: "g", localeCode: "en"), "")
     }
     
-    func testOverrideFilterCacheTranslated() {
-        let firstProviderTranslations: TXTranslations = [
+    func testUpdateUsingTranslatePolicy() {
+        let existingTranslations: TXTranslations = [
             "en": [
-                "key1": [ "string": "localized string 1" ]
+                "a": [ "string": "a" ],
+                "b": [ "string": "b" ],
+                "c": [ "string": "c" ],
+                "d": [ "string": "" ],
+                "e": [ "string": "" ]
             ]
         ]
-        let secondProviderTranslations: TXTranslations = [
-            "en": [
-                "key2": [ "string": "localized string 2" ]
-            ]
-        ]
-        
-        let firstProvider = MockCacheProvider(translations: firstProviderTranslations)
-        let secondProvider = MockCacheProvider(translations: secondProviderTranslations)
         
         let memoryCache =  TXMemoryCache()
-        memoryCache.update(translations: [
-            "en": [
-                "key1": [ "string": "old localized string 1"]
-            ]
-        ])
+        memoryCache.update(translations: existingTranslations)
         
+        let newTranslations: TXTranslations = [
+            "en": [
+                "b": [ "string": "B" ],
+                "c": [ "string": "" ],
+                "e": [ "string": "E" ],
+                "f": [ "string": "F" ],
+                "g": [ "string": "" ]
+            ]
+        ]
+        let provider = MockCacheProvider(translations: newTranslations)
+
         let cache = TXProviderBasedCache(
-            providers: [
-                firstProvider,
-                secondProvider
-            ],
-            internalCache: TXStringOverrideFilterCache(
-                policy: .overrideUsingTranslatedOnly,
+            providers: [ provider ],
+            internalCache: TXStringUpdateFilterCache(
+                policy: .updateUsingTranslated,
                 internalCache: memoryCache
             )
         )
         
-        XCTAssertNotNil(cache.get(key: "key1", localeCode: "en"))
-        XCTAssertTrue(cache.get(key: "key1", localeCode: "en") == "localized string 1")
-        XCTAssertNotNil(cache.get(key: "key2", localeCode: "en"))
+        XCTAssertEqual(cache.get(key: "a", localeCode: "en"), "a")
+        XCTAssertEqual(cache.get(key: "b", localeCode: "en"), "B")
+        XCTAssertEqual(cache.get(key: "c", localeCode: "en"), "c")
+        XCTAssertEqual(cache.get(key: "d", localeCode: "en"), "")
+        XCTAssertEqual(cache.get(key: "e", localeCode: "en"), "E")
+        XCTAssertEqual(cache.get(key: "f", localeCode: "en"), "F")
+        XCTAssertNil(cache.get(key: "g", localeCode: "en"))
+    }
+    
+    func testReadOnlyCache() {
+        let existingTranslations: TXTranslations = [
+            "en": [
+                "a": [ "string": "a" ],
+                "b": [ "string": "b" ],
+                "c": [ "string": "c" ],
+                "d": [ "string": "" ],
+                "e": [ "string": "" ]
+            ]
+        ]
+        
+        let memoryCache =  TXMemoryCache()
+        memoryCache.update(translations: existingTranslations)
+        
+        let newTranslations: TXTranslations = [
+            "en": [
+                "b": [ "string": "B" ],
+                "c": [ "string": "" ],
+                "e": [ "string": "E" ],
+                "f": [ "string": "F" ]
+            ]
+        ]
+        let provider = MockCacheProvider(translations: newTranslations)
+
+        let cache = TXProviderBasedCache(
+            providers: [ provider ],
+            internalCache: TXStringUpdateFilterCache(
+                policy: .updateUsingTranslated,
+                internalCache: TXReadonlyCacheDecorator(internalCache: memoryCache)
+            )
+        )
+        
+        XCTAssertEqual(cache.get(), existingTranslations)
     }
     
     func testPlatformStrategyWithInvalidSourceString() {
@@ -472,13 +481,13 @@ final class TransifexTests: XCTestCase {
         ("testEncodingSourceStringMeta", testEncodingSourceStringMeta),
         ("testEncodingSourceString", testEncodingSourceString),
         ("testEncodingSourceStringWithMeta", testEncodingSourceStringWithMeta),
+        ("testExtractICUPlurals", testExtractICUPlurals),
         ("testFetchTranslations", testFetchTranslations),
         ("testFetchTranslationsNotReady", testFetchTranslationsNotReady),
-        ("testExtractICUPlurals", testExtractICUPlurals),
         ("testPushTranslations", testPushTranslations),
-        ("testOverrideFilterCacheAll", testOverrideFilterCacheAll),
-        ("testOverrideFilterCacheUntranslated", testOverrideFilterCacheUntranslated),
-        ("testOverrideFilterCacheTranslated", testOverrideFilterCacheTranslated),
+        ("testReplaceAllPolicy", testReplaceAllPolicy),
+        ("testUpdateUsingTranslatePolicy", testUpdateUsingTranslatePolicy),
+        ("testReadOnlyCache", testReadOnlyCache),
         ("testPlatformStrategyWithInvalidSourceString", testPlatformStrategyWithInvalidSourceString),
         ("testErrorPolicy", testErrorPolicy),
         ("testCurrentLocale", testCurrentLocale),


### PR DESCRIPTION
Refactors cache policies based on the latest discussion between
@dbendilas and @petrakeas.

The empty translations (`""`) are now added in the cache (depending on
the policy) and they are not filtered out.

A helpful cheat-sheet table has been added in the documentation of the
`TXCacheOverridePolicy` and the policy documentation has been also
updated.

The cache now defaults to the `.overrideUsingTranslatedOnly` instead of
the `.overrideAll` policy, if no policy is specified by the developer.

If a cache entry is found to contain an empty string during rendering,
the logic falls back to the missing policy.

The documentation of the `TXDiskCacheProvider` has been updated to
declare that it initializes the disk cache provider synchronously.