### PR TITLE
Preferred locale provider returns correct language code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Transifex iOS SDK 0.1.0
 
-*Febrary 4, 2021*
+*February 4, 2021*
 
 - Public release
+
+## Transifex iOS SDK 0.1.1
+
+*February 24, 2021*
+
+- Fixed preferred locale provider

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -300,7 +300,7 @@ Error rendering source string '\(sourceString)' with string to render '\(stringT
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "0.1.0"
+    internal static let version = "0.1.1"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Sources/Transifex/Locales.swift
+++ b/Sources/Transifex/Locales.swift
@@ -41,8 +41,15 @@ public final class TXPreferredLocaleProvider : NSObject {
         _currentLocale = TXPreferredLocaleProvider.getCurrentLocale()
     }
     
+    private static func getPreferredLocale() -> Locale {
+        guard let preferredIdentifier = Locale.preferredLanguages.first else {
+            return Locale.autoupdatingCurrent
+        }
+        return Locale(identifier: preferredIdentifier)
+    }
+
     private static func getCurrentLocale() -> String {
-        return NSLocale.autoupdatingCurrent.languageCode ?? "en"
+        return getPreferredLocale().languageCode ?? "en"
     }
 }
 

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -450,6 +450,22 @@ final class TransifexTests: XCTestCase {
         XCTAssertEqual(result, "ERROR")
     }
 
+    func testCurrentLocale() {
+        let appleLanguagesKey = "AppleLanguages"
+        let storedLanguages = UserDefaults.standard.value(forKey: appleLanguagesKey)
+        
+        UserDefaults.standard.set([ "el" ],
+                                  forKey: appleLanguagesKey)
+        
+        let locale = TXLocaleState(appLocales: [])
+        
+        XCTAssertEqual(locale.currentLocale,
+                       "el")
+        
+        UserDefaults.standard.set(storedLanguages,
+                                  forKey: appleLanguagesKey)
+    }
+    
     static var allTests = [
         ("testDuplicateLocaleFiltering", testDuplicateLocaleFiltering),
         ("testCurrentLocaleProvider", testCurrentLocaleProvider),
@@ -463,5 +479,8 @@ final class TransifexTests: XCTestCase {
         ("testOverrideFilterCacheAll", testOverrideFilterCacheAll),
         ("testOverrideFilterCacheUntranslated", testOverrideFilterCacheUntranslated),
         ("testOverrideFilterCacheTranslated", testOverrideFilterCacheTranslated),
+        ("testPlatformStrategyWithInvalidSourceString", testPlatformStrategyWithInvalidSourceString),
+        ("testErrorPolicy", testErrorPolicy),
+        ("testCurrentLocale", testCurrentLocale),
     ]
 }


### PR DESCRIPTION
`TXPreferredLocaleProvider` used to rely on the `NSLocale.autoupdatingCurrent` property to fetch the current locale of
the device, but the property was not returning the correct language code.

The updated code looks into the `preferredLanguages` property list of the `Locale` class instead, and if that list is not empty (which is usually the case), picks the first language and sets it as the current locale, which reflects the user choice.

On top of that, a new unit test method is added that adds the greek language in the list of the preferred languages and asserts whether that language code is returned by the `TXLocaleState.currentLocale` property.

Last, some existing unit tests that were not running are not enabled.