### PR TITLE
Bump SDK version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,9 @@
 
 - Applies minor refactors in cache logic
 - Renames override policy to update policy and improves documentation.
+
+## Transifex iOS SDK 0.1.3
+
+*March 22, 2021*
+
+- Fixes a minor version issue

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -300,7 +300,7 @@ Error rendering source string '\(sourceString)' with string to render '\(stringT
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "0.1.2"
+    internal static let version = "0.1.3"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"


### PR DESCRIPTION
Bumps the Transifex SDK version from 0.1.2 to 0.1.3 so that the
`TXNative.version` value matches the value of the SDK version git tag.