### PR TITLE
Expose getCache method to ObjC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,9 @@
 *March 22, 2021*
 
 - Fixes a minor version issue
+
+## Transifex iOS SDK 0.1.4
+
+*March 24, 2021*
+
+- Exposes `TXStandardCache.getCache` method in Objective-C.

--- a/Sources/Transifex/Cache.swift
+++ b/Sources/Transifex/Cache.swift
@@ -405,6 +405,7 @@ public final class TXStandardCache: NSObject {
     ///   memory cache with the stored contents from disk. Defaults to .replaceAll.
     ///   - groupIdentifier: The group identifier of the app, if the app makes use of the app groups
     /// entitlement. Defaults to nil.
+    @objc
     public static func getCache(updatePolicy: TXCacheUpdatePolicy = .replaceAll,
                                 groupIdentifier: String? = nil) -> TXCache {
         var providers: [TXCacheProvider] = []

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -300,7 +300,7 @@ Error rendering source string '\(sourceString)' with string to render '\(stringT
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "0.1.3"
+    internal static let version = "0.1.4"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"


### PR DESCRIPTION
* Exposes `TXStandardCache` `getCache` static method to Objective-C.
* Updates Changelog and version