### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,7 @@ TXNative.initialize(
 ### Fetching translations
 
 As soon as `fetchTranslations` is called, the SDK will attempt to download the 
-translations for all locales - except for the source locale - that are defined in the 
-initialization of `TXNative`. 
+translations for all locales that are defined in the initialization of `TXNative`. 
 
 The `fetchTranslations` method in the above examples is called as soon as the
 application launches, but that's not required. Depending on the application, the developer


### PR DESCRIPTION
Updates README by removing a sentence regarding the source locale not
being downloaded when `fetchTranslations` is called.