### PR TITLE
Improve error policy behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,9 @@
 - Introduces public `dispose()` method to destruct the `TXNative` singleton instance.
 - Adds tag filter support when fetching translations via the `fetchTranslations` method.
 - Exposes `TXSourceString` read-only properties.
+
+## Transifex iOS SDK 0.5.1
+
+*July 12, 2021*
+
+- Improves error policy behavior.

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -323,7 +323,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "0.1.4"
+    internal static let version = "0.5.1"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -265,6 +265,9 @@ class NativeCore : TranslationProvider {
         }
     }
     
+    /// Error string to be rendered when the error policy produces an exception.
+    private static let ERROR_FALLBACK = "ERROR"
+    
     /// Renders the translation to the current format, taking into account any variable placeholders.
     ///
     /// Delegates the rendering to the appropriate rendering strategy (ICU or platform).
@@ -298,10 +301,21 @@ class NativeCore : TranslationProvider {
 Error rendering source string '\(sourceString)' with string to render '\(stringToRender)'
  locale code: \(localeCode) params: \(params). Error: \(error)
 """)
-            return errorPolicy.get(sourceString: sourceString,
-                                   stringToRender: stringToRender,
-                                   localeCode: localeCode,
-                                   params: params)
+            do {
+                return try errorPolicy.get(sourceString: sourceString,
+                                           stringToRender: stringToRender,
+                                           localeCode: localeCode,
+                                           params: params)
+            }
+            catch {
+                Logger.error("""
+Error running error policy for source string '\(sourceString)' with string to
+render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
+\(error)
+""")
+                
+                return NativeCore.ERROR_FALLBACK
+            }
         }
     }
 }

--- a/Sources/Transifex/Policies.swift
+++ b/Sources/Transifex/Policies.swift
@@ -166,18 +166,18 @@ public protocol TXErrorPolicy {
     func get(sourceString: String,
              stringToRender: String,
              localeCode: String,
-             params: [String: Any]) -> String
+             params: [String: Any]) throws -> String
 }
 
 /**
- An error policy that simply returns the source string instead of the translation.
+ An error policy that simply returns the string that is going to be rendered in the UI instead of the translation.
  */
 public final class TXRenderedSourceErrorPolicy : TXErrorPolicy {
     
     public func get(sourceString: String,
                     stringToRender: String,
                     localeCode: String,
-                    params: [String: Any]) -> String {
-        return sourceString
+                    params: [String: Any]) throws -> String {
+        return stringToRender
     }
 }

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -120,8 +120,21 @@ class MockErrorPolicy : TXErrorPolicy {
     func get(sourceString: String,
              stringToRender: String,
              localeCode: String,
-             params: [String : Any]) -> String {
-        return "ERROR"
+             params: [String : Any]) throws -> String {
+        return "MOCKERROR"
+    }
+}
+
+class MockErrorPolicyException : TXErrorPolicy {
+    enum MockError: Error {
+        case generic
+    }
+    
+    func get(sourceString: String,
+             stringToRender: String,
+             localeCode: String,
+             params: [String : Any]) throws -> String {
+        throw MockError.generic
     }
 }
 
@@ -500,6 +513,21 @@ final class TransifexTests: XCTestCase {
         let result = TXNative.translate(sourceString: "source string", params: [:], context: nil)
 
         XCTAssertNotNil(result)
+        XCTAssertEqual(result, "MOCKERROR")
+    }
+    
+    func testErrorPolicyException() {
+        let localeState = TXLocaleState(sourceLocale: "en",
+                                        appLocales: ["fr"])
+        
+        TXNative.initialize(locales: localeState,
+                            token: "<token>",
+                            secret: "<secret>",
+                            errorPolicy: MockErrorPolicyException(),
+                            renderingStrategy: .icu)
+        
+        let result = TXNative.translate(sourceString: "source string", params: [:], context: nil)
+
         XCTAssertEqual(result, "ERROR")
     }
 


### PR DESCRIPTION
* `TXErrorPolicy` method `get()` is now marked as being able to throw
an exception.
* Exceptions thrown by the `get()` method are now caught by the
`render()` method of the `NativeCore` class. If an exception is caught,
it's logged and the "ERROR" string (`ERROR_FALLBACK`) is returned.
* `TXRenderedSourceErrorPolicy` now returns the string to render instead
of the source string so that the user will not see any placeholders in
the UI.
* Updates the documentation of the `TXRenderedSourceErrorPolicy` to
reflect the changes.
* Adds unit test regarding the "ERROR" string if the error policy throws
an exception.