### PR TITLE
Lookup source string as key to cache 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,11 @@
 - Updates endpoint logic for v2 of CDS.
 - Push translations method now also returns an array of errors.
 - Improves CDSHandler unit tests.
+
+## Transifex iOS SDK 1.0.1
+
+*September 22, 2021*
+
+- When rendering a translation the logic now first uses the original source 
+string as a key to look up to the cache and falls back to the generated hash
+key if the entry is not found.

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -226,12 +226,22 @@ class NativeCore : TranslationProvider {
                    context: String?) -> String {
         var translationTemplate: String?
         let localeToRender = localeCode ?? locales.currentLocale
-        let key = txGenerateKey(sourceString: sourceString,
-                                context: context)
-
-        translationTemplate = cache.get(key: key,
-                                        localeCode: localeToRender)
         
+        translationTemplate = cache.get(key: sourceString,
+                                        localeCode: localeToRender)
+
+        // If the source string cannot be found in the cache, try looking up
+        // the generated key for that source string, in case the developer has
+        // either used a previous version of the TXCli tool or passed the
+        // `hashKeys` argument on the push command.
+        if translationTemplate == nil {
+            let key = txGenerateKey(sourceString: sourceString,
+                                    context: context)
+
+            translationTemplate = cache.get(key: key,
+                                            localeCode: localeToRender)
+        }
+            
         var applyMissingPolicy = false
         
         /// If the string is not found in the cache, use the bypass localizer to look it up on the

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -334,7 +334,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "1.0.0"
+    internal static let version = "1.0.1"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"


### PR DESCRIPTION
Uses the source string as the key for cache lookup when rendering a
localized translation.

As a fallback, if the entry is not found, the logic also uses the hash
of that source string as a key for cache lookup.