### PR TITLE
Refactor TXPreferredLocaleProvider logic

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,11 @@ key if the entry is not found.
 
 - Adds method to activate SDK from a Swift Package.
 - Adds reference to SwiftUI limitation in README.
+
+## Transifex iOS SDK 1.0.3
+
+*December 27, 2022*
+
+- Fixes TXPreferredLocaleProvider so that it uses the correct language candidate
+based on user's preference and supported languages by the app developer.
+- Fixes deprecation warnings on Github action.

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -334,7 +334,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "1.0.2"
+    internal static let version = "1.0.3"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -572,20 +572,45 @@ final class TransifexTests: XCTestCase {
         XCTAssertEqual(result, "ERROR")
     }
 
-    func testCurrentLocale() {
+    func testCurrentLocaleNotFirstPreference() {
         let appleLanguagesKey = "AppleLanguages"
         let storedLanguages = UserDefaults.standard.value(forKey: appleLanguagesKey)
         
-        UserDefaults.standard.set([ "el" ],
+        UserDefaults.standard.set([ "nl", "fr" ],
                                   forKey: appleLanguagesKey)
         
-        let locale = TXLocaleState(appLocales: [])
+        let locale = TXLocaleState(sourceLocale: "en",
+                                   appLocales: [ "fr", "de", "es", "it"])
         
         XCTAssertEqual(locale.currentLocale,
-                       "el")
+                       "fr")
         
         UserDefaults.standard.set(storedLanguages,
                                   forKey: appleLanguagesKey)
+    }
+    
+    func testCurrentLocaleNotAnyPreference() {
+        let appleLanguagesKey = "AppleLanguages"
+        let storedLanguages = UserDefaults.standard.value(forKey: appleLanguagesKey)
+        
+        UserDefaults.standard.set([ "nl", "fr" ],
+                                  forKey: appleLanguagesKey)
+        
+        let locale = TXLocaleState(sourceLocale: "en",
+                                   appLocales: [ "de", "es", "it"])
+        
+        XCTAssertEqual(locale.currentLocale,
+                       "en")
+        
+        UserDefaults.standard.set(storedLanguages,
+                                  forKey: appleLanguagesKey)
+    }
+    
+    func testSourceLocalePosition() {
+        let locale = TXLocaleState(sourceLocale: "en",
+                                   appLocales: [ "fr", "el" ])
+        
+        XCTAssertTrue(locale.appLocales.first == "en")
     }
     
     func testTranslateWithSourceStringsInCache() {
@@ -661,7 +686,9 @@ final class TransifexTests: XCTestCase {
         ("testPlatformStrategyWithInvalidSourceString", testPlatformStrategyWithInvalidSourceString),
         ("testErrorPolicy", testErrorPolicy),
         ("testErrorPolicyException", testErrorPolicyException),
-        ("testCurrentLocale", testCurrentLocale),
+        ("testCurrentLocaleNotFirstPreference", testCurrentLocaleNotFirstPreference),
+        ("testCurrentLocaleNotAnyPreference", testCurrentLocaleNotAnyPreference),
+        ("testSourceLocalePosition", testSourceLocalePosition),
         ("testTranslateWithSourceStringsInCache", testTranslateWithSourceStringsInCache),
     ]
 }


### PR DESCRIPTION
The `TXPreferredLocaleProvider` class does not always report the current
locale to be used for localization correctly.

This is because the `TXPreferredLocaleProvider` implementation always
returns the first supported language from the Settings app, as set by
the user. That language, though, is not always the correct candidate, as
it might not be the most appropriate localization candidate, or not even
a valid candidate at all in some cases.

For example:

If user has set the following languages as their preference in the
Settings app: "Dutch", "French" and the supported languages for
localization in the app are "French", "English", "German", "Spanish"
and "Italian" then the correct language should be "French" and not
"Dutch" that is the first preferred language of the user.

Similarly, if "French" was not a supported language for localization on
the above example, then the logic must return "English" and not "Dutch".

In order to fix this issue, the `TXPreferredLocaleProvider` class needs
to be aware of the supported app locales (that are provided by the
developer) and also respect the order of preferred languages (that are
set by the user in the Settings app).

The method responsible for that is
`Bundle.preferredLocalizations(from:, forPreferences:)` and is now used
in the `getCurrentLocale()` method of `TXPreferredLocaleProvider` to
return the proper locale.

The `getPreferredLocale()` is now being used only as a fallback and has
been refactored for better readability and the final fallback locale
code ("en") has been made a static property (`FALLBACK_LOCALE`).

The `TXPreferredLocaleProvider` initializer now accepts the list of
supported application locales (set by the developer) as they are needed
for the aforementioned calculation.

Also, the list of the `appLocales` as calculated in the initializer of
the `TXLocaleState` has been altered so that the source locale is
always added first, in order to align with one of the internal quirks of
the `Bundle.preferredLocalizations()` method that fallsback to the first
language of its provided `localizationsArray` argument.

The `testCurrentLocale` unit test has been refactored to test against
the scenario where the correct locale is not the first language set by
the user and more unit tests have been added.

Ref:
* https://developer.apple.com/library/archive/technotes/tn2418/_index.html
* https://medium.com/@hectorricardomendez/ios-bad-news-bundle-preferredlocalizations-is-not-100-reliable-13fa33454d14