### PR TITLE
Add documentation action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Docs
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: macos-12
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Clean and prepare docs branch
+      run: |
+        git fetch origin docs
+        git branch -D docs &>/dev/null || true
+        git checkout -b docs
+    - name: Install Jazzy
+      run: gem install jazzy
+    - name: Run Jazzy
+      run: jazzy -g https://github.com/transifex/transifex-swift -m Transifex
+    - name: Commit files
+      run: |
+        git add .
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git commit -a -m "CI: Automated build push" | exit 0
+    - name: Push changes
+      run: git push -f --set-upstream origin docs
+


### PR DESCRIPTION
Adds `docs.yml` Github action for automating the documentation generation.

The action performs the following logic:

* Activates when a push to `master` occurs (new release).
* Fetches the `docs` branch from `origin`.
* Deletes it and creates a new `docs` branch from `master`.
* Installs and runs Jazzy.
* Commits the changes.
* Force pushes the changes in the `docs` branch to `origin`.