### PR TITLE
Various improvements

### DIFF
--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -181,10 +181,11 @@ class NativeCore : TranslationProvider {
     ///   - purge: Whether to replace the entire resource  content (true) or not (false). Defaults to false.
     ///   - completionHandler: A callback to be called when the push operation is complete with a
     /// boolean argument that informs the caller that the operation was successful (true) or not (false) and
-    /// an array that may or may not contain any errors produced during the push operation.
+    /// an array that may or may not contain any errors produced during the push operation and an array of
+    /// non-blocking errors (warnings) that may have been generated during the push procedure.
     func pushTranslations(_ translations: [TXSourceString],
                           purge: Bool = false,
-                          completionHandler: @escaping (Bool, [Error]) -> Void) {
+                          completionHandler: @escaping (Bool, [Error], [Error]) -> Void) {
         cdsHandler.pushTranslations(translations,
                                     purge: purge,
                                     completionHandler: completionHandler)
@@ -538,11 +539,12 @@ token: \(token)
     ///   - purge: Whether to replace the entire resource content (true) or not (false). Defaults to false.
     ///   - completionHandler: A callback to be called when the push operation is complete with a
     /// boolean argument that informs the caller that the operation was successful (true) or not (false) and
-    /// an array that may or may not contain any errors produced during the push operation.
+    /// an array that may or may not contain any errors produced during the push operation and an array of
+    /// non-blocking errors (warnings) that may have been generated during the push procedure.
     @objc
     public static func pushTranslations(_ translations: [TXSourceString],
                                         purge: Bool = false,
-                                        completionHandler: @escaping (Bool, [Error]) -> Void) {
+                                        completionHandler: @escaping (Bool, [Error], [Error]) -> Void) {
         tx?.pushTranslations(translations,
                              purge: purge,
                              completionHandler: completionHandler)

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -504,6 +504,23 @@ token: \(token)
         )
     }
     
+    /// Helper method used when translation is not possible (e.g. in SwiftUI views).
+    ///
+    /// This method applies the translation using the currently selected locale. For pluralization use the
+    /// `localizedString(format:arguments:)` method.
+    ///
+    /// Make sure that this method is called after the SDK has been initialized, otherwise
+    /// "<SDK NOT INITIALIZED>" string will be shown instead.
+    ///
+    /// - Parameter sourceString: The source string to be translated
+    /// - Returns: The translated string
+    public static func t(_ sourceString: String) -> String {
+        return tx?.translate(sourceString: sourceString,
+                             localeCode: nil,
+                             params: [:],
+                             context: nil) ?? "<SDK NOT INITIALIZED>"
+    }
+
     /// Used by the Swift localizedString(format:arguments:) methods found in the
     /// TXExtensions.swift file.
     public static func localizedString(format: String,

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -537,7 +537,7 @@ final class TransifexTests: XCTestCase {
                                     session: urlSession)
         
         var pushResult = false
-        cdsHandler.pushTranslations(translations) { (result, errors) in
+        cdsHandler.pushTranslations(translations) { (result, errors, warnings) in
             pushResult = result
             expectation.fulfill()
         }
@@ -601,7 +601,7 @@ final class TransifexTests: XCTestCase {
                                     session: urlSession)
         
         var pushResult = false
-        cdsHandler.pushTranslations(translations) { (result, errors) in
+        cdsHandler.pushTranslations(translations) { (result, errors, warnings) in
             pushResult = result
             expectation.fulfill()
         }


### PR DESCRIPTION
### Improve CDSHandler push logic

The `pushTranslations()` method now returns a secondary array of `Error`
objects in the completion handler that represents the generated warnings
during the processing of the source strings that are non-fatal but can
be of interest to the developer.

This change introduces a new enum (`TXCDSWarning`) that hosts those
warnings, like duplicate source string and empty key detection.

The `pushTranslations()` logic has been improved by implementing the
following changes:

* `serializeTranslations()` is now a private static method as it does
not need to look into the state of the `CDSHandler` instance.
* That method now returns a tuple that includes a `Result<Data>` object
as the first member, revealing whether the serialization
was successful, thus offering the `Data` object, or a failure, thus
offering a `Error` object for further propagation and an array of
`TXCDSWarning` objects for any generated warnings during the processing
of the source strings.
* The `pushTranslations()` implementation has been split so that it's
easier to be read. The new method that performs the asynchronous network
operation is now separate (`pushData()`) and propagates the generated
warnings to the `pollJobStatus()` method.
* Any error logging has been removed in favor of the list of `Error`
objects in the completion handler. The logging is now a responsibility
of the consumer.

---

### Introduce t() method

A new public static method has been introduced in the `TXNative` class,
allowing developers to programmatically trigger the translation
mechanism of Transifex SDK in cases where this is not supported.

For example, in SwiftUI, where the swizzling mechanism of Transifex SDK
does currently work, developers can replace views like this:

```
Text("test string")
```

with this:

```
Text(TXNative.t("test string"))
```

The method uses the default locale that Transifex SDK has been
configured with.

Note: If you want to change the current locale used by the
SwiftUI preview to test different locales, click on the 'Product' menu
item and then visit 'Scheme' > 'Edit Scheme...' > 'Run' > 'Options' >
'App Language' and pick the language you want to test.