### PR TITLE
Introduce push configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,16 @@ based on user's preference and supported languages by the app developer.
 - Tags and status filters can be either specified during initialization and/or
 when `fetchTranslations()` is called.
 - Fixes issue where the passed custom session was not being used.
+
+## Transifex iOS SDK 2.0.0
+
+*July 7, 2023*
+
+- Adds `t()` translation method for cases where Transifex iOS logic cannot
+intercept the localization (e.g. SwiftUI).
+- `pushTranslations()` now reports back any generated warnings as a separate
+array.
+- Push logic detects and reports warnings such as duplicate source string keys
+or empty source string keys.
+- `pushTranslations()` now accepts a configuration object that holds any extra
+options that might need to be set during the push logic.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ method.
 * `sourceString` (required): The actual source string.
 * `developerComment` (optional): An optional comment provided by the developer to
 assist the translators.
-* `occurrencies` (required): A list of relative paths where the source string is located in
+* `occurrences` (required): A list of relative paths where the source string is located in
 the project.
 * `tags` (optional): An optional list of tags that will appear alongside the source string in
 the Transifex dashboard.

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -353,7 +353,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "1.0.4"
+    internal static let version = "2.0.0"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -178,16 +178,17 @@ class NativeCore : TranslationProvider {
     ///
     /// - Parameters:
     ///   - translations: A list of `TXSourceString` objects.
-    ///   - purge: Whether to replace the entire resource  content (true) or not (false). Defaults to false.
+    ///   - configuration: A configuration object containing all the options that will be used alongside
+    ///   the push operation (see `TXPushConfiguration`).
     ///   - completionHandler: A callback to be called when the push operation is complete with a
     /// boolean argument that informs the caller that the operation was successful (true) or not (false) and
     /// an array that may or may not contain any errors produced during the push operation and an array of
     /// non-blocking errors (warnings) that may have been generated during the push procedure.
     func pushTranslations(_ translations: [TXSourceString],
-                          purge: Bool = false,
+                          configuration: TXPushConfiguration = TXPushConfiguration(),
                           completionHandler: @escaping (Bool, [Error], [Error]) -> Void) {
         cdsHandler.pushTranslations(translations,
-                                    purge: purge,
+                                    configuration: configuration,
                                     completionHandler: completionHandler)
     }
     
@@ -553,17 +554,18 @@ token: \(token)
     ///
     /// - Parameters:
     ///   - translations: A list of `TXSourceString` objects.
-    ///   - purge: Whether to replace the entire resource content (true) or not (false). Defaults to false.
+    ///   - configuration: A configuration object containing all the options that will be used alongside
+    ///   the push operation (see `TXPushConfiguration`).
     ///   - completionHandler: A callback to be called when the push operation is complete with a
     /// boolean argument that informs the caller that the operation was successful (true) or not (false) and
     /// an array that may or may not contain any errors produced during the push operation and an array of
     /// non-blocking errors (warnings) that may have been generated during the push procedure.
     @objc
     public static func pushTranslations(_ translations: [TXSourceString],
-                                        purge: Bool = false,
+                                        configuration: TXPushConfiguration = TXPushConfiguration(),
                                         completionHandler: @escaping (Bool, [Error], [Error]) -> Void) {
         tx?.pushTranslations(translations,
-                             purge: purge,
+                             configuration: configuration,
                              completionHandler: completionHandler)
     }
     


### PR DESCRIPTION
Introduces the `TXPushConfiguration` object that can hold the different configuration options available for the push translations functionality and adds any missing options:

* Adds `overrideTags`, `overrideOccurrences`, `keepTranslations` and `dryRun` options.
* Moves `purge` inside the `TXPushConfiguration`.
* Ensures that the proper JSON keys are used when encoding the above options.
* Adds documentation.
* Replaces the `purge` argument of the `pushTranslations()` methods with the `TXPushConfiguration` object, ensuring that the default value holds the correct default values for each option.
* Fixes small typo on README.