### PR TITLE
Version 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,3 +99,13 @@ array.
 or empty source string keys.
 - `pushTranslations()` now accepts a configuration object that holds any extra
 options that might need to be set during the push logic.
+
+## Transifex iOS SDK 2.0.1
+
+*September 21, 2023*
+
+- Addresses language tag discrepancy: The fallback mechanism for accessing the
+bundled source locale translations, in case the target translations was not
+found, was trying to access the file by using the format that Transifex uses
+(e.g. `en_US`) instead of the one that iOS and Xcode use (e.g. `en-US`). The
+logic now normalizes the locale name to match the format that iOS accepts.

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -361,7 +361,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.0"
+    internal static let version = "2.0.1"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"


### PR DESCRIPTION
- Addresses language tag discrepancy: The fallback mechanism for accessing the
bundled source locale translations, in case the target translations was not
found, was trying to access the file by using the format that Transifex uses
(e.g. `en_US`) instead of the one that iOS and Xcode use (e.g. `en-US`). The
logic now normalizes the locale name to match the format that iOS accepts.