### PR TITLE
SwiftUI support

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,3 +117,9 @@ logic now normalizes the locale name to match the format that iOS accepts.
 - Adds full support for String Catalogs support.
 - Adds support for substitution phrases on old Strings Dictionary file format.
 - Updates unit tests.
+
+## Transifex iOS SDK 2.0.3
+
+*June 3, 2024*
+
+- Adds SwiftUI support via attributed string swizzling.

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
         .testTarget(
             name: "TransifexObjCTests",
             dependencies: [
+                "Transifex",
                 "TransifexObjCRuntime",
             ]
         ),

--- a/README.md
+++ b/README.md
@@ -378,10 +378,6 @@ Description strings) that are included in the `InfoPList.strings` file.
 * Localized entried found in the `Root.plist` of the `Settings.bundle` of an app that
 exposes its Settings to the iOS Settings app that are included in the `Root.strings` file.
 
-### SwiftUI
-
-The SDK does not currently support SwiftUI views.
-
 ### ICU support
 
 Also, currently SDK supports only supports the platform rendering strategy, so if the ICU

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -501,7 +501,14 @@ token: \(token)
         
         Swizzler.activate(bundles: [bundle])
     }
-    
+
+    /// Deactivates swizzling for the Bundle previously passed in the `activate(bundle:)` method.
+    /// - Parameter bundle: the bundle to be deactivated.
+    @objc
+    public static func deactivate(bundle: Bundle) {
+        Swizzler.deactivate(bundles: [bundle])
+    }
+
     /// Return the translation of the given source string on a certain locale.
     ///
     /// - Parameters:
@@ -599,9 +606,11 @@ token: \(token)
         tx?.forceCacheInvalidation(completionHandler: completionHandler)
     }
     
-    /// Destructs the TXNative singleton instance so that another one can be used.
+    /// Destructs the TXNative singleton instance so that another one can be used. Reverts swizzled
+    /// classes and methods.
     @objc
     public static func dispose() {
+        Swizzler.deactivate()
         tx = nil
     }
 }

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -361,7 +361,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.2"
+    internal static let version = "2.0.3"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Sources/Transifex/RenderingStrategy.swift
+++ b/Sources/Transifex/RenderingStrategy.swift
@@ -40,7 +40,8 @@ class ICUMessageFormat : RenderingStrategyFormatter {
 
 /// The platform rendering strategy
 class PlatformFormat : RenderingStrategyFormatter {
-    
+    internal static let TRANSIFEX_STRINGSDICT_KEY = "Transifex.StringsDict.TestKey.%d"
+
     /// Returns the proper plural rule to use based on the given locale and arguments.
     ///
     /// In order to find the correct rule, it takes advantage of Apple's localization framework
@@ -50,7 +51,7 @@ class PlatformFormat : RenderingStrategyFormatter {
     /// business logic from scratch.
     static func extractPluralizationRule(locale: Locale,
                                          argument: CVarArg) -> PluralizationRule {
-        let key = NSLocalizedString("Transifex.StringsDict.TestKey.%d",
+        let key = NSLocalizedString(TRANSIFEX_STRINGSDICT_KEY,
                                     bundle: Bundle.module,
                                     comment: "")
         let pluralizationRule = String(format: key,

--- a/Sources/TransifexObjCRuntime/include/TXNativeObjcSwizzler.h
+++ b/Sources/TransifexObjCRuntime/include/TXNativeObjcSwizzler.h
@@ -41,8 +41,25 @@ typedef NS_ENUM(NSInteger, TXNativeObjcArgumentType) {
 ///
 /// @param closure A provided block that will be called when the localizedStringWithFormat: method
 /// is called.
-+ (void)activateWithClosure:(NSString* (^)(NSString *format,
-                                           NSArray <TXNativeObjcArgument *> *arguments))closure;
++ (void)swizzleLocalizedStringWithClosure:(NSString* (^)(NSString *format,
+                                                         NSArray <TXNativeObjcArgument *> *arguments))closure;
+
+/// Deactivate swizzling for Objective C NSString.localizedStringWithFormat: method.
++ (void)revertLocalizedString;
+
+/// Swizzle the `localizedAttributedStringForKey:value:table:` NSBundle method using
+/// the provided class and method from the caller.
+///
+/// @param class The caller class that contains the swizzled selector.
+/// @param selector The swizzled selector.
++ (void)swizzleLocalizedAttributedString:(Class)class selector:(SEL)selector;
+
+/// Deactivate swizzling for `localizedAttributedStringForKey:value:table:` NSBundle
+/// method.
+///
+/// @param class The caller class that contains the swizzled selector.
+/// @param selector The swizzled selector.
++ (void)revertLocalizedAttributedString:(Class)class selector:(SEL)selector;
 
 @end
 

--- a/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
+++ b/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
@@ -8,16 +8,41 @@
 
 #import <XCTest/XCTest.h>
 #import "TXNativeObjcSwizzler.h"
+@import Transifex;
+
+@interface MockLocaleProvider : NSObject <TXCurrentLocaleProvider>
+
+@property (nonatomic) NSString *mockLocaleCode;
+
+@end
+
+@implementation MockLocaleProvider
+
+- (instancetype)initWithMockLocaleCode:(NSString *)localeCode {
+    if (self = [super init]) {
+        self.mockLocaleCode = localeCode;
+    }
+
+    return self;
+}
+
+- (NSString *)currentLocale {
+    return self.mockLocaleCode;
+}
+
+@end
 
 @interface TXNativeObjcSwizzlerTests : XCTestCase
+
++ (NSString* (^)(NSString *format, NSArray <TXNativeObjcArgument *> *arguments)) closure;
 
 @end
 
 @implementation TXNativeObjcSwizzlerTests
 
-- (void)setUp {
-    [TXNativeObjcSwizzler activateWithClosure:^NSString * (NSString *format,
-                                                           NSArray<TXNativeObjcArgument *> *arguments) {
++ (NSString* (^)(NSString *format, NSArray <TXNativeObjcArgument *> *arguments)) closure {
+    return ^NSString * (NSString *format,
+                        NSArray<TXNativeObjcArgument *> * arguments) {
         NSMutableArray *argumentList = [NSMutableArray new];
         [arguments enumerateObjectsUsingBlock:^(TXNativeObjcArgument *obj,
                                                 NSUInteger idx,
@@ -28,23 +53,68 @@
         return [NSString stringWithFormat:@"format: %@ arguments: %@",
                 format,
                 args];
-    }];
+    };
 }
 
 - (void)testOneInt {
+    [TXNativeObjcSwizzler swizzleLocalizedStringWithClosure:self.class.closure];
+
     NSString *finalString = [NSString localizedStringWithFormat:@"Test %d",
                              1];
     NSString *expectedString = @"format: Test %d arguments: 1";
-    
-    XCTAssertTrue([finalString isEqualToString:expectedString]);
+
+    XCTAssertEqualObjects(finalString, expectedString);
+
+    [TXNativeObjcSwizzler revertLocalizedString];
 }
 
 - (void)testOneFloatOneString {
+    [TXNativeObjcSwizzler swizzleLocalizedStringWithClosure:self.class.closure];
+
     NSString *finalString = [NSString localizedStringWithFormat:@"Test %f %@",
                              3.14, @"Test"];
     NSString *expectedString = @"format: Test %f %@ arguments: 3.14,Test";
-    
-    XCTAssertTrue([finalString isEqualToString:expectedString]);
+
+    XCTAssertEqualObjects(finalString, expectedString);
+
+    [TXNativeObjcSwizzler revertLocalizedString];
+}
+
+- (void)testAttributed API_AVAILABLE(macos(12.0)) {
+    TXMemoryCache *memoryCache = [TXMemoryCache new];
+    [memoryCache updateWithTranslations:@{
+        @"en": @{
+            @"a": @{ @"string": @"a" }
+        },
+        @"el": @{
+            @"a": @{ @"string": @"α" }
+        },
+    }];
+
+    MockLocaleProvider *mockLocaleProvider = [MockLocaleProvider.alloc initWithMockLocaleCode:@"el"];
+
+    TXLocaleState *localeState = [TXLocaleState.alloc initWithSourceLocale:@"en"
+                                                                appLocales:@[ @"el" ]
+                                                     currentLocaleProvider:mockLocaleProvider];
+
+    [TXNative initializeWithLocales:localeState
+                              token:@"<token>"
+                             secret:nil
+                            cdsHost:nil
+                            session:nil
+                              cache:memoryCache
+                      missingPolicy:nil
+                        errorPolicy:nil
+                  renderingStrategy:TXRenderingStategyPlatform
+                         filterTags:nil
+                       filterStatus:nil];
+
+    NSString *string = [NSBundle.mainBundle localizedAttributedStringForKey:@"a"
+                                                                      value:nil
+                                                                      table:nil].string;
+    XCTAssertEqualObjects(string, @"α");
+
+    [TXNative dispose];
 }
 
 @end

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -685,7 +685,32 @@ final class TransifexTests: XCTestCase {
             XCTAssertTrue(pushResult)
         }
     }
-    
+
+    func testNSLocalizedString() {
+        let existingTranslations: TXTranslations = [
+            "en": [
+                "a": [ "string": "a" ],
+            ],
+            "el": [
+                "a": [ "string": "α" ],
+            ]
+        ]
+
+        let localeState = TXLocaleState(sourceLocale: "en",
+                                        appLocales: ["el"],
+                                        currentLocaleProvider: MockLocaleProvider("el"))
+
+        let memoryCache =  TXMemoryCache()
+        memoryCache.update(translations: existingTranslations)
+
+        TXNative.initialize(locales: localeState,
+                            token: Self.testToken,
+                            cache: memoryCache,
+                            renderingStrategy: .platform)
+        
+        XCTAssertEqual(NSLocalizedString("a", comment: ""), "α")
+    }
+
     func testReplaceAllPolicy() {
         let existingTranslations: TXTranslations = [
             "en": [
@@ -808,17 +833,12 @@ final class TransifexTests: XCTestCase {
     func testPlatformStrategyWithInvalidSourceString() {
         let localeState = TXLocaleState(sourceLocale: "en",
                                         appLocales: ["fr"])
+
+        TXNative.initialize(locales: localeState,
+                            token: Self.testToken,
+                            renderingStrategy: .platform)
         
-        let core = NativeCore(locales: localeState,
-                              token: Self.testToken,
-                              secret: nil,
-                              cdsHost: nil,
-                              cache: nil,
-                              renderingStrategy: .platform)
-        
-        let result = core.render(sourceString: "test", stringToRender: nil, localeCode: "", params: [
-                        Swizzler.PARAM_ARGUMENTS_KEY: [1, 2] as [CVarArg]
-        ])
+        let result = TXNative.localizedString(format: "test", arguments: [1,2] as [CVarArg])
         
         XCTAssertNotNil(result)
         XCTAssertEqual(result, "test")
@@ -1116,6 +1136,7 @@ final class TransifexTests: XCTestCase {
         ("testFetchTranslationsNotReady", testFetchTranslationsNotReady),
         ("testPushTranslations", testPushTranslations),
         ("testPushTranslationsNotReady", testPushTranslationsNotReady),
+        ("testNSLocalizedString", testNSLocalizedString),
         ("testReplaceAllPolicy", testReplaceAllPolicy),
         ("testUpdateUsingTranslatePolicy", testUpdateUsingTranslatePolicy),
         ("testReadOnlyCache", testReadOnlyCache),


### PR DESCRIPTION
### SwiftUI support

* Adds attributed string swizzling that allows Transifex SDK to allow
for SwiftUI support.
* De-swizzles methods when SDK is deactivated (when `dispose` is
called).
* Adds public static method to deactivate swizzling on passed `Bundle`
instance.
* Ensures that the special Transifex `.stringsdict` key used to
calculate the plural rules, cannot be swizzled
(`TRANSIFEX_STRINGSDICT_KEY`).
* Ensures that SDK is properly deactivated when a unit test finishes, so
that swizzling is re-applied correctly on each test.
* Adds unit test for the `localizedAttributedString:...` method in
Objective-C.
* Adds unit test for the `NSLocalizedString()` method in Swift.

NOTE: SwiftUI elements (`View`, `Button` etc) cannot be added to unit
tests.

---

### Bump version to 2.0.3

* Bumps `TXNative.version` to 2.0.3.
* Updates CHANGELOG with the changes implemented for 2.0.3.