### PR TITLE
Update minimum supported versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,3 +123,9 @@ logic now normalizes the locale name to match the format that iOS accepts.
 *June 3, 2024*
 
 - Adds SwiftUI support via attributed string swizzling.
+
+## Transifex iOS SDK 2.0.4
+
+*June 21, 2024*
+
+- Updates minimum supported OS versions.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,10 @@ import PackageDescription
 let package = Package(
     name: "transifex",
     platforms: [
-        .iOS(.v10)
+        .iOS(.v12),
+        .watchOS(.v4),
+        .tvOS(.v12),
+        .macOS(.v10_13)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ The SDK can fetch translations over the air (OTA), manages an internal cache of 
 and works seamlessly without requiring any changes in the source code of the app by the
 developer.
 
-Both Objective-C and Swift projects are supported and iOS 10+ is required.
+Both Objective-C and Swift projects are supported.
 
 The package is built using Swift 5.3, as it currently requires a bundled resource to be
-present in the package (which was introduced on version 5.3). An update that will require
-a lower Swift version is currently WIP.
+present in the package (feature introduced in version 5.3).
 
 Learn more about [Transifex Native](https://developers.transifex.com/docs/native).
 
@@ -24,9 +23,9 @@ The full SDK documentation is available at [https://transifex.github.io/transife
 
 ## Minimum Requirements
 
-| Swift           | Xcode           | Platforms                                         |
-|-----------------|-----------------|---------------------------------------------------|
-| Swift 5.3       | Xcode 12.3      | iOS 10.0  |
+| Swift           | Xcode            | Platforms                                            |
+|-----------------|------------------|------------------------------------------------------|
+| Swift 5.3       | Xcode 15.4       | iOS 12.0, watchOS 4.0, tvOS 12.0, macOS 10.13        |
 
 ## Usage
 

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -361,7 +361,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.3"
+    internal static let version = "2.0.4"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
+++ b/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
@@ -80,7 +80,7 @@
     [TXNativeObjcSwizzler revertLocalizedString];
 }
 
-- (void)testAttributed API_AVAILABLE(macos(12.0)) {
+- (void)testAttributed API_AVAILABLE(macos(12.0), ios(15.0), watchos(8.0), tvos(15.0)) {
     TXMemoryCache *memoryCache = [TXMemoryCache new];
     [memoryCache updateWithTranslations:@{
         @"en": @{


### PR DESCRIPTION
### Update minimum supported versions

Updates minimum supported OS versions on the package manifest
and on README.

Also updates the `testAttributed` unit test target availability
decorator with the supported OS versions.

Minimum Xcode version was updated to match the latest Xcode
release (15.4).

---

### Bump version to 2.0.4

* Bumps `TXNative.version` to 2.0.4.
* Updates CHANGELOG with the changes implemented for 2.0.4.