### PR TITLE
Version 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,3 +129,12 @@ logic now normalizes the locale name to match the format that iOS accepts.
 *June 21, 2024*
 
 - Updates minimum supported OS versions.
+
+## Transifex iOS SDK 2.0.5
+
+*July 3, 2024*
+
+* Ensures that callbacks won't capture `self` strongly.
+* Ensures Designed for iPhone/iPad apps use the proper device name.
+* Discloses that completion handlers are called from background threads.
+* Improves cache update after a `fetchTranslations` call.

--- a/Sources/Transifex/Cache.swift
+++ b/Sources/Transifex/Cache.swift
@@ -265,7 +265,11 @@ public final class TXFileOutputCacheDecorator: TXDecoratorCache {
     public override func update(translations: TXTranslations) {
         super.update(translations: translations)
         
-        cacheQueue.async {
+        cacheQueue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
             guard let fileURL = self.fileURL else {
                 return
             }

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -164,7 +164,8 @@ class NativeCore : TranslationProvider {
     /// - Parameter status: An optional status so that only strings matching translation status are
     /// fetched.
     /// - Parameter completionHandler: The completion handler that informs the caller with the
-    /// new translations and a list of possible errors that might have occured
+    /// new translations and a list of possible errors that might have occured. The completion handler is
+    /// called from a background thread.
     func fetchTranslations(_ localeCode: String? = nil,
                            tags: [String] = [],
                            status: String? = nil,
@@ -195,7 +196,8 @@ class NativeCore : TranslationProvider {
     ///   - completionHandler: A callback to be called when the push operation is complete with a
     /// boolean argument that informs the caller that the operation was successful (true) or not (false) and
     /// an array that may or may not contain any errors produced during the push operation and an array of
-    /// non-blocking errors (warnings) that may have been generated during the push procedure.
+    /// non-blocking errors (warnings) that may have been generated during the push procedure. The
+    /// completion handler is called from a background thread.
     func pushTranslations(_ translations: [TXSourceString],
                           configuration: TXPushConfiguration = TXPushConfiguration(),
                           completionHandler: @escaping (Bool, [Error], [Error]) -> Void) {
@@ -213,7 +215,7 @@ class NativeCore : TranslationProvider {
     ///
     /// - Parameter completionHandler: A callback to be called when force cache invalidation is
     /// complete with a boolean argument that informs the caller that the operation was successful (true) or
-    /// not (false).
+    /// not (false).  The completion handler is called from a background thread.
     func forceCacheInvalidation(completionHandler: @escaping (Bool) -> Void) {
         cdsHandler.forceCacheInvalidation { [weak self] success in
             guard let _ = self else {
@@ -580,6 +582,7 @@ token: \(token)
     ///   - status: An optional status so that only strings matching translation status are fetched.
     ///   - completionHandler: The completion handler that informs the caller when the operation
     ///   is complete, reporting the new translations and a list of possible errors that might have occured.
+    ///   The completion handler is called from a background thread.
     @objc
     public static func fetchTranslations(_ localeCode: String? = nil,
                                          tags: [String]? = nil,
@@ -600,7 +603,8 @@ token: \(token)
     ///   - completionHandler: A callback to be called when the push operation is complete with a
     /// boolean argument that informs the caller that the operation was successful (true) or not (false) and
     /// an array that may or may not contain any errors produced during the push operation and an array of
-    /// non-blocking errors (warnings) that may have been generated during the push procedure.
+    /// non-blocking errors (warnings) that may have been generated during the push procedure. The
+    /// completion handler is called from a background thread.
     @objc
     public static func pushTranslations(_ translations: [TXSourceString],
                                         configuration: TXPushConfiguration = TXPushConfiguration(),
@@ -614,7 +618,7 @@ token: \(token)
     ///
     /// - Parameter completionHandler: A callback to be called when force cache invalidation is
     /// complete with a boolean argument that informs the caller that the operation was successful (true) or
-    /// not (false).
+    /// not (false).  The completion handler is called from a background thread.
     @objc
     public static func forceCacheInvalidation(completionHandler: @escaping (Bool) -> Void) {
         tx?.forceCacheInvalidation(completionHandler: completionHandler)

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -181,7 +181,21 @@ class NativeCore : TranslationProvider {
                 Logger.error("\(#function) Errors: \(errors)")
             }
 
-            self.cache.update(translations: translations)
+            // Only update the cache if the translations structure is not
+            // empty, avoiding cases where no translations were fetched due
+            // to errors (e.g. network offline etc).
+            // We do not check for errors here as some translations might
+            // have failed and some others might not. As long as the
+            // translations structure is not empty, we are OK to update the
+            // cache (and, by extension, the stored file).
+            if !translations.isEmpty {
+                // Update cache using the fetched translations in main thread
+                // to ensure proper cache updates for custom implemented caching
+                // solutions.
+                DispatchQueue.main.async {
+                    self.cache.update(translations: translations)
+                }
+            }
 
             completionHandler?(translations, errors)
         }

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -391,7 +391,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.4"
+    internal static let version = "2.0.5"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"


### PR DESCRIPTION
* Ensures that callbacks won't capture `self` strongly.
* Ensures "Designed for iPhone"/ "Designed for iPad" apps use the proper device name.
* Discloses that completion handlers are called from background threads.
* Improves cache update after a `fetchTranslations` call.