### PR TITLE
Updates docs CI runner image from MacOS 12 to MacOS 14

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
MacOS 12 runner was failing when trying to build the project for the `jazzy` gem that generates the documentation.