### PR TITLE
2.0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,3 +144,13 @@ logic now normalizes the locale name to match the format that iOS accepts.
 *July 9, 2024*
 
 * Minor documentation updates.
+
+## Transifex iOS SDK 2.0.6
+
+*February 19, 2025*
+
+* Allows `TXLogger.handler` to be reset.
+* Addresses compiler warning for `SwizzledBundle`.
+* Logging improvements.
+* `TXCDSError` enum improvements.
+* Addresses issue with attributed string creation.

--- a/Sources/Transifex/Cache.swift
+++ b/Sources/Transifex/Cache.swift
@@ -155,7 +155,7 @@ public final class TXDiskCacheProvider: NSObject, TXCacheProvider {
             fileData = try Data(contentsOf: fileURL)
         }
         catch {
-            Logger.warning("\(#function) fileURL: \(fileURL) Data error: \(error)")
+            Logger.warning("fileURL: \(fileURL) Data error: \(error)")
         }
         
         guard let data = fileData else {
@@ -169,7 +169,7 @@ public final class TXDiskCacheProvider: NSObject, TXCacheProvider {
                                                           from: data)
         }
         catch {
-            Logger.error("\(#function) fileURL: \(fileURL) Decode Error: \(error)")
+            Logger.error("fileURL: \(fileURL) Decode Error: \(error)")
             return nil
         }
         
@@ -193,7 +193,7 @@ public final class TXDiskCacheProvider: NSObject, TXCacheProvider {
                 }
                 // Process it and synthesize the final rule.
                 guard let processedString = XMLPluralParser.extract(pluralString: sourceString) else {
-                    Logger.error("\(#function) Error attempting to extract source string with key \(sourceStringKey)")
+                    Logger.error("Error attempting to extract source string with key \(sourceStringKey)")
                     continue
                 }
                 // Replace the source string with the processed value
@@ -279,7 +279,7 @@ public final class TXFileOutputCacheDecorator: TXDecoratorCache {
                                            fileURL: fileURL)
             }
             catch {
-                Logger.error("\(#function) Error: \(error)")
+                Logger.error("Error storing translations: \(error)")
             }
         }
     }

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -391,7 +391,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.6"
+    internal static let version = "2.0.7"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -178,7 +178,7 @@ class NativeCore : TranslationProvider {
             }
 
             if errors.count > 0 {
-                Logger.error("\(#function) Errors: \(errors)")
+                Logger.error("Errors while fetching translations from CDS: [\n\(errors.map { "  \($0)" }.joined(separator: "\n"))\n]")
             }
 
             // Only update the cache if the translations structure is not

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -464,8 +464,8 @@ public final class TXNative : NSObject {
         
         Logger.verbose("""
 Initializing TXNative(
-locales: \(locales.debugDescription)
-token: \(token)
+  locales: \(locales.debugDescription)
+  token: \(token)
 )
 """)
         

--- a/Sources/Transifex/Logging.swift
+++ b/Sources/Transifex/Logging.swift
@@ -61,7 +61,7 @@ public final class TXLogger: NSObject {
     ///
     /// - Parameter handler: The new log handler to be used
     @objc
-    public static func setHandler(handler: TXLogHandler) {
+    public static func setHandler(handler: TXLogHandler?) {
         Logger.handler = handler
     }
     

--- a/Sources/Transifex/Swizzler.swift
+++ b/Sources/Transifex/Swizzler.swift
@@ -157,9 +157,17 @@ class Swizzler {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     private static func attributedString(with swizzledString: String) -> NSAttributedString {
+        // Use the .inlineOnlyPreservingWhitespace to prevent the Markdown
+        // engine from trimming whitespace characters, respecting the original
+        // string value whilst applying any Markdown renderning.
+        // In SwiftUI the `Text()` element will produce the same effect either
+        // with .inlineOnly or .inlineOnlyPreservingWhitespace but we opt in
+        // always preserving whitespace where possible.
+        let markdownOptions = AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
         var string: AttributedString
         do {
-            string = try AttributedString(markdown: swizzledString)
+            string = try AttributedString(markdown: swizzledString,
+                                          options: markdownOptions)
         }
         catch {
             // Fallback to the non-Markdown version in case of an error

--- a/Sources/Transifex/Swizzler.swift
+++ b/Sources/Transifex/Swizzler.swift
@@ -11,7 +11,7 @@ import TransifexObjCRuntime
 
 /// Swizzles all localizedString() calls made either by Storyboard files or by the use of NSLocalizedString()
 /// function in code.
-class SwizzledBundle : Bundle {
+class SwizzledBundle : Bundle, @unchecked Sendable {
     // NOTE:
     // We can't override the `localizedAttributedString(forKey:value:table:)`
     // method here, as it's not exposed in Swift.


### PR DESCRIPTION
* Allows `TXLogger.handler` to be reset.
* Addresses compiler warning for `SwizzledBundle`.
* Logging improvements.
* `TXCDSError` enum improvements.
* Addresses issue with attributed string creation.