### PR TITLE
`String.init(localized:...)` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@ logic now normalizes the locale name to match the format that iOS accepts.
 
 * Minor documentation updates.
 
-## Transifex iOS SDK 2.0.6
+## Transifex iOS SDK 2.0.7
 
 *February 19, 2025*
 
@@ -154,3 +154,13 @@ logic now normalizes the locale name to match the format that iOS accepts.
 * Logging improvements.
 * `TXCDSError` enum improvements.
 * Addresses issue with attributed string creation.
+
+## Transifex iOS SDK 2.0.8
+
+*March 11, 2025*
+
+* `String(localized:...)` support.
+* Updates `README.md` by adding a 'Supported localization methods' section and
+updating the 'Limitations' section.
+* Refactors `BypassLocalizer` class.
+* Updates `TXNativeExtensions.swift`.

--- a/README.md
+++ b/README.md
@@ -97,8 +97,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 For Swift projects, you  will also need to copy the `TXNativeExtensions.swift` file in
 your project and include it in all of the targets that call any of the following Swift methods:
 
-* `String.localizedStringWithFormat(format:...)`
-* `NSString.localizedStringWithFormat(format:...)`
+* `NSString.localizedStringWithFormat(_ format:, _ args:)`
+* `String.localizedStringWithFormat(_ format:, _ arguments:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:options:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:defaultValue:table:bundle:locale:comment:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:defaultValue:options:table:bundle:locale:comment:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:table:bundle:locale:comment:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:options:table:bundle:locale:comment:)`
 
 If none of your application targets call any of the above methods, then you don't need to
 add this file to your project.
@@ -170,6 +176,36 @@ TXNative.initialize(
 [TXNative initializeWithLocales:localeState
                           token:@"<transifex_token>"];
 ```
+
+### Supported localization methods
+
+On runtime, Transifex SDK overrides / swizzles the following localization
+methods and structures in order to ensure that the application source code does
+not require any changes:
+
+* `NSLocalizedString(_ key:tableName:bundle:value:comment:)`
+* `NSString.localizedStringWithFormat(_ format:, _ args:)`
+* `String.localizedStringWithFormat(_ format:, _ arguments:)`
+* `-[NSString localizedStringWithFormat:]`
+* `NSBundle.localizedString(forKey:value:table:)`
+* `-[NSBundle localizedAttributedStringForKey:value:table:]`
+* Any SwiftUI view initializer that accepts a `LocalizedStringKey` struct.
+* [⚠️](#stringlocalized-initializers) `String.init(localized:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:options:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:defaultValue:table:bundle:locale:comment:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:defaultValue:options:table:bundle:locale:comment:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:table:bundle:locale:comment:)`
+* [⚠️](#stringlocalized-initializers) `String.init(localized:options:table:bundle:locale:comment:)`
+
+Developers are also able to use the public methods of `TXNative` class if they
+want to (`t(_:)`, `localizedString(format:arguments:)`, `translate(...)`.
+
+> [!WARNING]
+>
+> Please note that if the 'Use Compiler to Extract Swift Strings' build settting
+> is enabled (`SWIFT_EMIT_LOC_STRINGS`) and you use any of the `TXNative` publicly
+> provided methods, the strings will not be automatically collected when building
+> the application.
 
 ### Fetching translations
 
@@ -366,6 +402,47 @@ protocol so that they can control the logging mechanism of the SDK or make use o
 public `TXStandardLogHandler` class to control the log level printed to the console.
 
 ## Limitations
+
+### `String(localized:)` initializers
+
+While the `String(localized:)` family of initializers ([^1] [^2] [^3] [^4] [^5] [^6])
+is supported through the `TXNativeExtensions.swift` file, we do not recommend using
+them due to their reliance on reflection and regular expressions to extract the
+`LocalizationValue` properties.
+
+Developers can choose to switch between the Reflection and the Regular Expression
+extraction logic via the `extractionType` argument of the `TXNative.translate(...)`
+methods used in the `TXNativeExtensions.swift` file.
+
+> [!WARNING]
+>
+> **Risk of Breaking Changes**
+>
+> Apple may change the internal representation of the `LocalizationValue`
+> struct at any time, which would break the implemented logic.
+
+We strongly recommend using any of the following supported methods instead of
+the `String(localized:)` initializers:
+
+* `NSLocalizedString(_ key:tableName:bundle:value:comment:)`
+* `NSString.localizedStringWithFormat(_ format:, _ args:)`
+* `String.localizedStringWithFormat(_ format:, _ arguments:)`
+* `-[NSString localizedStringWithFormat:]`
+* `NSBundle.localizedString(forKey:value:table:)`
+* `-[NSBundle localizedAttributedStringForKey:value:table:]`
+* Any SwiftUI view initializer that accepts a `LocalizedStringKey` struct.
+
+If you understand the risks, you may uncomment the relevant section in
+`TXNativeExtensions.swift` after adding the file to your application’s
+target(s). However, we strongly advise using the recommended
+alternatives whenever possible.
+
+[^1]: https://developer.apple.com/documentation/swift/string/init(localized:)
+[^2]: https://developer.apple.com/documentation/swift/string/init(localized:options:)
+[^3]: https://developer.apple.com/documentation/swift/string/init(localized:defaultvalue:table:bundle:locale:comment:)
+[^4]: https://developer.apple.com/documentation/swift/string/init(localized:defaultvalue:options:table:bundle:locale:comment:)
+[^5]: https://developer.apple.com/documentation/swift/string/init(localized:table:bundle:locale:comment:)
+[^6]: https://developer.apple.com/documentation/swift/string/init(localized:options:table:bundle:locale:comment:)
 
 ### Special cases
 

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -443,7 +443,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.7"
+    internal static let version = "2.0.8"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -54,21 +54,73 @@ final class BypassLocalizer {
 
         self.bundle = Bundle(path: bundlePath)
     }
-    
+
+    /// Initializer bypass localizer with a certain bundle.
+    ///
+    /// - Parameter bundle: The bundle to be used.
+    init(with bundle: Bundle) {
+        self.bundle = bundle
+    }
+
+    /// Convenience initializer that uses the provided `Bundle` instance and if that is `nil` looks up
+    /// the bundle via the provided locale identifier.
+    ///
+    /// - Parameters:
+    ///   - bundle: The optional Bundle instance to be used
+    ///   - localeCode: The locale identifier.
+    private convenience init(with bundle: Bundle?,
+                             localeCode: String) {
+        if let bundle = bundle {
+            self.init(with: bundle)
+        }
+        else {
+            self.init(with: localeCode)
+        }
+    }
+
+    /// Creates a temporary BypassLocalizer instance using the provided bundle or the locale (if the bundle
+    /// instance is nil) and then attempts to extract the bundled `sourceString` using the provided
+    /// `params` dictionary.
+    ///
+    /// - Parameters:
+    ///   - sourceString: The source string to extract from the bundled translations.
+    ///   - bundle: The bundle to look into.
+    ///   - locale: The locale code to be used to look up the bundle if the `bundle` argument is `nil`
+    ///   - params: The params dictionary
+    /// - Returns: The bundled string or the `sourceString` if the bundle string cannot be extracted.
+    static func get(sourceString: String,
+                    bundle: Bundle?,
+                    locale: Locale, params: [String: Any]) -> String {
+        return Self
+            .init(with: bundle,
+                  localeCode: locale.identifier)
+            .get(sourceString: sourceString,
+                 params: params)
+    }
+
     private func extractBundledString(sourceString: String,
                                       params: [String: Any]) -> String? {
-        guard let bundle = bundle else {
-            return nil
+        // Bundle.main is the fallback if no bundle is provided.
+        var currentBundle = Bundle.main
+
+        // If a bundle has been provided in the params dictionary, use that
+        // instead of the one that the instance has been instantiated with.
+        if let bundleInstance = params[Swizzler.PARAM_BUNDLE_KEY] as? Bundle {
+            currentBundle = bundleInstance
         }
-        
+        // Otherwise if the instance bundle is not nil, use that.
+        else if let bundle = bundle {
+            currentBundle = bundle
+        }
+
         let tableName = params[Swizzler.PARAM_TABLE_KEY] as? String
         
         // We use the SKIP_SWIZZLING_VALUE constant to skip swizzling for this
         // call, so that the actual value can be retrieved, if it exists in the
         // application bundle.
-        let localizedString = bundle.localizedString(forKey: sourceString,
-                                                     value: Swizzler.SKIP_SWIZZLING_VALUE,
-                                                     table: tableName)
+        let localizedString = currentBundle.localizedString(forKey: sourceString,
+                                                            value: Swizzler.SKIP_SWIZZLING_VALUE,
+                                                            table: tableName)
         
         if  localizedString != Swizzler.SKIP_SWIZZLING_VALUE {
             return localizedString
@@ -561,7 +613,315 @@ Initializing TXNative(
             context: context
         )
     }
-    
+
+    /// Translate a string from the
+    /// `String.init(localized:options:table:bundle:locale:comment:)` initializer.
+    ///
+    /// Warning: This method uses reflection to extract the properties of the `localizationValue`
+    /// argument. Proceed with caution.
+    ///
+    /// - Parameters:
+    ///   - localizationValue: A localization value instance that provides the localization key to
+    ///   look up. This parameter also serves as the default value if the system can’t find a localized string.
+    ///   - options: A localization options instance that specifies localization options to apply, such as
+    ///   replacement values for formatted strings.
+    ///   - table: The bundle’s string table to search. If table is nil or is an empty string, the method
+    ///   attempts to use the table named Localizable. The default is nil.
+    ///   - bundle: The bundle to use for looking up strings. If nil, an app searches its main bundle.
+    ///   The default is nil.
+    ///   - locale: The locale to use when localizing interpolated values, such as numbers. This
+    ///   doesn’t change which locale the system uses to look up the localized string. If nil, this initializer
+    ///   uses the current locale. The default is nil.
+    ///   - extractionType: The extraction type to be used when trying to extract the properties of
+    ///   the `LocalizationValue` struct. The value is set to .reflection by default.
+    /// - Returns: The final string to be displayed to the user or the bundled string if the Transifex SDK
+    /// is not available or if the string is not found in the Transifex SDK cache.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    public static func translate(localizationValue: String.LocalizationValue,
+                                 options: String.LocalizationOptions,
+                                 table: String? = nil,
+                                 bundle: Bundle? = nil,
+                                 locale: Locale = .current,
+                                 extractionType: String.LocalizationValue.ExtractionType = .reflection) -> String {
+        let extracted = localizationValue.extract(extractionType)
+
+        let sourceString = extracted.key
+        let args = extracted.combinedArgs(with: options)
+
+        var params: [String: Any] = [:]
+        
+        if args.count > 0 {
+            params[Swizzler.PARAM_ARGUMENTS_KEY] = args
+        }
+
+        if let table = table {
+            params[Swizzler.PARAM_TABLE_KEY] = table
+        }
+        
+        if let bundle = bundle {
+            params[Swizzler.PARAM_BUNDLE_KEY] = bundle
+        }
+
+        if let tx = tx {
+            return tx.translate(sourceString: sourceString,
+                                params: params,
+                                context: nil)
+        }
+        else {
+            return BypassLocalizer.get(sourceString: sourceString,
+                                       bundle: bundle,
+                                       locale: locale,
+                                       params: params)
+        }
+    }
+
+    /// Translate a string from the
+    /// `String.init(localized:defaultValue:options:table:bundle:locale:comment:)`
+    /// initializer.
+    ///
+    /// Warning: This method uses reflection to extract the properties of the `defaultValue`
+    /// argument. Proceed with caution.
+    ///
+    /// - Parameters:
+    ///   - staticString: An arbitrary static string key.
+    ///   - defaultValue: A default value to use if looking up a localized string from the bundle fails.
+    ///   This is typically the localizable string in the development language.
+    ///   - options: A localization options instance that specifies localization options to apply, such as
+    ///   replacement values for formatted strings.
+    ///   - table: The bundle’s string table to search. If table is nil or is an empty string, the method
+    ///   attempts to use the table named Localizable. The default is nil.
+    ///   - bundle: The bundle to use for looking up strings. If nil, an app searches its main bundle.
+    ///   The default is nil.
+    ///   - locale: The locale to use when localizing interpolated values, such as numbers. This
+    ///   doesn’t change which locale the system uses to look up the localized string. If nil, this initializer
+    ///   uses the current locale. The default is nil.
+    ///   - extractionType: The extraction type to be used when trying to extract the properties of
+    ///   the `LocalizationValue` struct. The value is set to .reflection by default.
+    /// - Returns: The final string to be displayed to the user or the bundled string if the Transifex SDK
+    /// is not available or if the string is not found in the Transifex SDK cache.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    public static func translate(staticString: StaticString,
+                                 defaultValue: String.LocalizationValue,
+                                 options: String.LocalizationOptions,
+                                 table: String? = nil,
+                                 bundle: Bundle? = nil,
+                                 locale: Locale = .current,
+                                 extractionType: String.LocalizationValue.ExtractionType = .reflection) -> String {
+        let sourceString = staticString.withUTF8Buffer {
+            String(decoding: $0, as: UTF8.self)
+        }
+
+        let extracted = defaultValue.extract(extractionType)
+
+        let args = extracted.combinedArgs(with: options)
+
+        var params: [String: Any] = [
+            Swizzler.PARAM_VALUE_KEY: extracted.key
+        ]
+
+        if args.count > 0 {
+            params[Swizzler.PARAM_ARGUMENTS_KEY] = args
+        }
+
+        if let table = table {
+            params[Swizzler.PARAM_TABLE_KEY] = table
+        }
+
+        if let bundle = bundle {
+            params[Swizzler.PARAM_BUNDLE_KEY] = bundle
+        }
+
+        if let tx = tx {
+            return tx.translate(sourceString: sourceString,
+                                params: params,
+                                context: nil)
+        }
+        else {
+            return BypassLocalizer.get(sourceString: sourceString,
+                                       bundle: bundle,
+                                       locale: locale,
+                                       params: params)
+        }
+    }
+
+    /// Translate a string from the following initializers:
+    /// * `String.init(localized:)`
+    /// * `String.init(localized:options:)`
+    ///
+    /// Warning: This method uses reflection to extract the properties of the `resource.defaultValue`
+    /// argument. Proceed with caution.
+    ///
+    /// - Parameters:
+    ///   - resource: A LocalizedStringResource that provides the localization key, table, bundle, and
+    ///   locale.
+    ///   - options: A localization options instance that specifies localization options to apply, such as
+    ///   replacement values for formatted strings.
+    ///   - extractionType: The extraction type to be used when trying to extract the properties of
+    ///   the `LocalizationValue` struct. The value is set to .reflection by default.
+    /// - Returns: The final string to be displayed to the user or the bundled string if the Transifex SDK
+    /// is not available or if the string is not found in the Transifex SDK cache.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    public static func translate(resource: LocalizedStringResource,
+                                 options: String.LocalizationOptions? = nil,
+                                 extractionType: String.LocalizationValue.ExtractionType = .reflection) -> String {
+        let sourceString = resource.key
+
+        let extracted = resource.defaultValue.extract(extractionType)
+
+        let args = extracted.combinedArgs(with: options)
+
+        var params: [String: Any] = [
+            Swizzler.PARAM_VALUE_KEY: extracted.key
+        ]
+
+        if args.count > 0 {
+            params[Swizzler.PARAM_ARGUMENTS_KEY] = args
+        }
+
+        if let table = resource.table {
+            params[Swizzler.PARAM_TABLE_KEY] = table
+        }
+
+        let bundle = Bundle.from(description: resource.bundle)
+
+        if let bundle = bundle {
+            params[Swizzler.PARAM_BUNDLE_KEY] = bundle
+        }
+
+        if let tx = tx {
+            return tx.translate(sourceString: sourceString,
+                                params: params,
+                                context: nil)
+        }
+        else {
+            return BypassLocalizer.get(sourceString: sourceString,
+                                       bundle: bundle,
+                                       locale: resource.locale,
+                                       params: params)
+        }
+    }
+
+    /// Translate a string from the `String.init(localized:table:bundle:locale:comment:)`
+    /// initializer.
+    ///
+    /// Warning: This method uses reflection to extract the properties of the `localizationValue`
+    /// argument. Proceed with caution.
+    ///
+    /// - Parameters:
+    ///   - localizationValue: A String.LocalizationValue that provides the localization key to look
+    ///   up. This parameter also serves as the default value if the system can’t find a localized string.
+    ///   - table: The bundle’s string table to search. If table is nil or is an empty string, the method
+    ///   attempts to use the table named Localizable. The default is nil.
+    ///   - bundle: The bundle to use for looking up strings. If nil, an app searches its main bundle.
+    ///   The default is nil.
+    ///   - locale: The locale to use when localizing interpolated values, such as numbers. This
+    ///   doesn’t change which locale the system uses to look up the localized string. If nil, this initializer
+    ///   uses the current locale. The default is nil.
+    ///   - extractionType: The extraction type to be used when trying to extract the properties of
+    ///   the `LocalizationValue` struct. The value is set to .reflection by default.
+    /// - Returns: The final string to be displayed to the user or the bundled string if the Transifex SDK
+    /// is not available or if the string is not found in the Transifex SDK cache.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public static func translate(localizationValue: String.LocalizationValue,
+                                 table: String? = nil,
+                                 bundle: Bundle? = nil,
+                                 locale: Locale = .current,
+                                 extractionType: String.LocalizationValue.ExtractionType = .reflection) -> String {
+        let extracted = localizationValue.extract(extractionType)
+
+        let sourceString = extracted.key
+
+        var params: [String: Any] = [:]
+
+        if extracted.args.count > 0 {
+            params[Swizzler.PARAM_ARGUMENTS_KEY] = extracted.args
+        }
+
+        if let table = table {
+            params[Swizzler.PARAM_TABLE_KEY] = table
+        }
+
+        if let bundle = bundle {
+            params[Swizzler.PARAM_BUNDLE_KEY] = bundle
+        }
+
+        if let tx = tx {
+            return tx.translate(sourceString: sourceString,
+                                params: params,
+                                context: nil)
+        }
+        else {
+            return BypassLocalizer.get(sourceString: sourceString,
+                                       bundle: bundle,
+                                       locale: locale,
+                                       params: params)
+        }
+    }
+
+    /// Translate a string from the
+    /// `String.init(localized:defaultValue:table:bundle:locale:comment:)`
+    /// initializer.
+    ///
+    /// Warning: This method uses reflection to extract the properties of the `defaultValue`
+    /// argument. Proceed with caution.
+    ///
+    /// - Parameters:
+    ///   - staticString: An arbitrary static string key.
+    ///   - defaultValue: A default value to use if looking up a localized string from the bundle fails.
+    ///   This is typically the localizable string in the development language.
+    ///   - table: The bundle’s string table to search. If table is nil or is an empty string, the method
+    ///   attempts to use the table named Localizable. The default is nil.
+    ///   - bundle: The bundle to use for looking up strings. If nil, an app searches its main bundle.
+    ///   The default is nil.
+    ///   - locale: The locale to use when localizing interpolated values, such as numbers. This
+    ///   doesn’t change which locale the system uses to look up the localized string. If nil, this initializer
+    ///   uses the current locale. The default is nil.
+    ///   - extractionType: The extraction type to be used when trying to extract the properties of
+    ///   the `LocalizationValue` struct. The value is set to .reflection by default.
+    /// - Returns: The final string to be displayed to the user or the bundled string if the Transifex SDK
+    /// is not available or if the string is not found in the Transifex SDK cache.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public static func translate(staticString: StaticString,
+                                 defaultValue: String.LocalizationValue,
+                                 table: String? = nil,
+                                 bundle: Bundle? = nil,
+                                 locale: Locale = .current,
+                                 extractionType: String.LocalizationValue.ExtractionType = .reflection) -> String {
+        let sourceString = staticString.withUTF8Buffer {
+            String(decoding: $0, as: UTF8.self)
+        }
+
+        let extracted = defaultValue.extract(extractionType)
+
+        var params: [String: Any] = [
+            Swizzler.PARAM_VALUE_KEY: extracted.key
+        ]
+
+        if extracted.args.count > 0 {
+            params[Swizzler.PARAM_ARGUMENTS_KEY] = extracted.args
+        }
+
+        if let table = table {
+            params[Swizzler.PARAM_TABLE_KEY] = table
+        }
+
+        if let bundle = bundle {
+            params[Swizzler.PARAM_BUNDLE_KEY] = bundle
+        }
+
+        if let tx = tx {
+            return tx.translate(sourceString: sourceString,
+                                params: params,
+                                context: nil)
+        }
+        else {
+            return BypassLocalizer.get(sourceString: sourceString,
+                                       bundle: bundle,
+                                       locale: locale,
+                                       params: params)
+        }
+    }
+
     /// Helper method used when translation is not possible (e.g. in SwiftUI views).
     ///
     /// This method applies the translation using the currently selected locale. For pluralization use the

--- a/Sources/Transifex/Swizzler.swift
+++ b/Sources/Transifex/Swizzler.swift
@@ -61,6 +61,7 @@ class Swizzler {
     internal static let PARAM_VALUE_KEY = "_value"
     internal static let PARAM_TABLE_KEY = "_table"
     internal static let PARAM_ARGUMENTS_KEY = "_arguments"
+    internal static let PARAM_BUNDLE_KEY = "_bundle"
     
     /// String to be returned when no translation provider is provided
     private static let MISSING_PROVIDER = "MISSING TRANSLATION PROVIDER"

--- a/Sources/Transifex/TXNativeExtensions.swift
+++ b/Sources/Transifex/TXNativeExtensions.swift
@@ -8,10 +8,20 @@
 
 // Note:
 // Please copy this file to your project and add it to all of the app's targets
-// if you are making use of either of the following Swift methods:
+// if you are making use of the following Swift methods:
 //
-// * NSString.localizedStringWithFormat()
-// * String.localizedStringWithFormat()
+// * NSString.localizedStringWithFormat(_ format:, _ args:)
+// * String.localizedStringWithFormat(_ format:, _ arguments:)
+//
+// For the String.init(localized:...) initializers below, please consult the
+// 'Limitations' section of README.md before un-commenting that section of the
+// code:
+// * String.init(localized:)
+// * String.init(localized:options:)
+// * String.init(localized:defaultValue:table:bundle:locale:comment:)
+// * String.init(localized:defaultValue:options:table:bundle:locale:comment:)
+// * String.init(localized:table:bundle:locale:comment:)
+// * String.init(localized:options:table:bundle:locale:comment:)
 //
 // If your code makes use of the Objective-C's
 // [NSString localizedStringWithFormat:...] method, you don't need to copy this
@@ -51,3 +61,62 @@ public extension NSString {
         return localized
     }
 }
+/**
+/// Replace String(localized:) initializers.
+///
+/// Please consult the 'Limitations' section of README.md for more information.
+public extension String {
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    init(localized key: StaticString, defaultValue: String.LocalizationValue,
+         table: String? = nil, bundle: Bundle? = nil, locale: Locale = .current,
+         comment: StaticString? = nil) {
+        self = TXNative.translate(staticString: key, defaultValue: defaultValue,
+                                  table: table, bundle: bundle, locale: locale,
+                                  extractionType: .reflection)
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    init(localized keyAndValue: String.LocalizationValue, table: String? = nil,
+         bundle: Bundle? = nil, locale: Locale = .current,
+         comment: StaticString? = nil) {
+        self = TXNative.translate(localizationValue: keyAndValue, table: table,
+                                  bundle: bundle, locale: locale,
+                                  extractionType: .reflection)
+    }
+
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    init(localized resource: LocalizedStringResource) {
+        self = TXNative.translate(resource: resource,
+                                  extractionType: .reflection)
+    }
+
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    init(localized resource: LocalizedStringResource,
+         options: String.LocalizationOptions) {
+        self = TXNative.translate(resource: resource, options: options,
+                                  extractionType: .reflection)
+    }
+
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    init(localized key: StaticString, defaultValue: String.LocalizationValue,
+         options: String.LocalizationOptions, table: String? = nil,
+         bundle: Bundle? = nil, locale: Locale = .current,
+         comment: StaticString? = nil) {
+        self = TXNative.translate(staticString: key, defaultValue: defaultValue,
+                                  options: options, table: table,
+                                  bundle: bundle, locale: locale,
+                                  extractionType: .reflection)
+    }
+
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    init(localized keyAndValue: String.LocalizationValue,
+         options: String.LocalizationOptions, table: String? = nil,
+         bundle: Bundle? = nil, locale: Locale = .current,
+         comment: StaticString? = nil) {
+        self = TXNative.translate(localizationValue: keyAndValue,
+                                  options: options, table: table,
+                                  bundle: bundle, locale: locale,
+                                  extractionType: .reflection)
+    }
+}
+**/

--- a/Sources/Transifex/utils.swift
+++ b/Sources/Transifex/utils.swift
@@ -91,3 +91,317 @@ extension String {
         return String(self[indexStart..<indexEnd])
     }
 }
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.LocalizationValue {
+    /// Struct containing the extracted key and arguments of the `LocalizationValue`
+    internal struct ExtractedLocalizationValue {
+        var key: String
+        var args: [Any]
+
+        /// Combines the extracted `arguments` with the `replacements` array from the
+        /// `String.LocalizationOptions` struct.
+        ///
+        /// - Parameter options: The options structure.
+        /// - Returns: The combined arguments where placeholder elements have been replaced
+        /// with the replacement values.
+        @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+        func combinedArgs(with options: String.LocalizationOptions?) -> [Any] {
+            // The replacements array must exist.
+            guard var replacements = options?.replacements else {
+                return args
+            }
+
+            // The replacements array must have a size equal to the number of
+            // placeholder elements in the extracted args array.
+            guard args
+                .filter({ $0 is String.LocalizationValue.Placeholder })
+                .count == replacements.count else {
+                return args
+            }
+
+            var combinedArgs: [Any] = []
+
+            args.forEach { arg in
+                // Add the non-placeholder elements
+                guard arg is String.LocalizationValue.Placeholder else {
+                    combinedArgs.append(arg)
+                    return
+                }
+                // Given the 2nd guard statement, that shouldn't happen but
+                // it's here as a sanity check.
+                guard let firstReplacement = replacements.first else {
+                    combinedArgs.append(arg)
+                    return
+                }
+                // Add the first replacement and remove it.
+                //
+                // NOTE: We may also want to check if the placeholderArg enum
+                // value matches the type of the firstReplacement object.
+                //
+                combinedArgs.append(firstReplacement)
+                replacements.removeFirst()
+            }
+
+            return combinedArgs
+        }
+    }
+
+    // The extraction to be performed: Reflection or Regular expression
+    public enum ExtractionType {
+        case reflection
+        case regex
+    }
+
+    // Default key value to be used when key extraction fails.
+    private static let EXTRACTION_FAILED_KEY = "extraction_failed"
+
+    /// Extract the underlying `key` and `arguments` of the `LocalizationValue` struct using
+    /// either reflection (default) or regular expression.
+    ///
+    /// If the properties cannot be extracted, the `key` will be the `extraction_failed` string and the
+    /// `arguments` array will be empty.
+    ///
+    /// - Parameter extractionType: The extraction type (reflection or regular expression).
+    /// - Returns: The extracted location value.
+    internal func extract(_ extractionType: ExtractionType = .reflection) -> ExtractedLocalizationValue {
+        /// The reflection logic assumes the following internal structure for the `LocalizationValue`
+        /// struct:
+        /// - key (String)
+        /// - arguments (Array of LocalizationValue.FormatArgument.Storage)
+        ///   - storage
+        ///     - value or String.LocalizationValue.Placeholder
+        switch extractionType {
+        case .reflection:
+            return ExtractedLocalizationValue(key: extractKeyReflection() ?? Self.EXTRACTION_FAILED_KEY,
+                                              args: extractArgumentsReflection())
+        case .regex:
+            return ExtractedLocalizationValue(key: extractKeyRegex() ?? Self.EXTRACTION_FAILED_KEY,
+                                              args: extractArgumentsRegex())
+        }
+    }
+
+    // MARK: Reflection
+    private static let MIRROR_LABEL_KEY = "key"
+    private static let MIRROR_LABEL_ARGS = "arguments"
+    private static let MIRROR_LABEL_STORAGE = "storage"
+    private static let MIRROR_LABEL_VALUE = "value"
+    private static let MIRROR_LABEL_PLACEHOLDER = "placeholder"
+
+    /// Extracts the key from the `LocalizationValue` using reflection.
+    ///
+    /// - Returns: The extracted key or `nil`.
+    private func extractKeyReflection() -> String? {
+        return Mirror(reflecting: self)
+            .children
+            .first(where: { $0.label == Self.MIRROR_LABEL_KEY })?
+            .value as? String
+    }
+
+    /// Extract the arguments from the `LocalizationValue` using reflection.
+    ///
+    /// - Returns: The extracted arguments or an empty array.
+    private func extractArgumentsReflection() -> [Any] {
+        var localizationValueArguments: [Any] = []
+
+        if let args = Mirror(reflecting: self)
+            .children
+            .first(where: { $0.label == Self.MIRROR_LABEL_ARGS })?
+            .value as? [Any] {
+            args.forEach { arg in
+                if let storage = Mirror(reflecting: arg)
+                    .children
+                    .first(where: { $0.label == Self.MIRROR_LABEL_STORAGE })?
+                    .value {
+                    if let value = Mirror(reflecting: storage)
+                        .children
+                        .first(where: { $0.label == Self.MIRROR_LABEL_VALUE })?
+                        .value {
+                        if let intValue = value as? Int {
+                            localizationValueArguments.append(intValue as CVarArg)
+                        } else if let uintValue = value as? UInt {
+                            localizationValueArguments.append(uintValue as CVarArg)
+                        } else if let floatValue = value as? Float {
+                            localizationValueArguments.append(floatValue as CVarArg)
+                        } else if let doubleValue = value as? Double {
+                            localizationValueArguments.append(doubleValue as CVarArg)
+                        } else if let valueVarArg = value as? CVarArg {
+                            localizationValueArguments.append(valueVarArg)
+                        }
+                        return
+                    }
+    #if os(iOS)
+                    if #available(iOS 16, *),
+                        let placeholder = extractPlaceholderReflection(storage) {
+                        localizationValueArguments.append(placeholder)
+                    }
+    #elseif os(watchOS)
+                    if #available(watchOS 9, *),
+                        let placeholder = extractPlaceholderReflection(storage) {
+                        localizationValueArguments.append(placeholder)
+                    }
+    #elseif os(tvOS)
+                    if #available(tvOS 16, *),
+                        let placeholder = extractPlaceholderReflection(storage) {
+                        localizationValueArguments.append(placeholder)
+                    }
+    #elseif os(macOS)
+                    if #available(macOS 13, *),
+                        let placeholder = extractPlaceholderReflection(storage) {
+                        localizationValueArguments.append(placeholder)
+                    }
+    #endif
+                }
+            }
+        }
+
+        return localizationValueArguments
+    }
+
+    /// Extract the underlying LocalizationValue.Placeholder enum from a storage property using reflection.
+    ///
+    /// - Parameter storage: The storage property
+    /// - Returns: The LocalizationValue.Placeholder enum value, `nil` if extraction is not possible.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    private func extractPlaceholderReflection(_ storage: Any) -> String.LocalizationValue.Placeholder? {
+        return Mirror(reflecting: storage)
+            .children
+            .first(where: { $0.label == Self.MIRROR_LABEL_PLACEHOLDER})?
+            .value as? String.LocalizationValue.Placeholder
+    }
+
+    // MARK: Regular expression
+    private static let KEY_REGEX = #"key:\s*"([^"]*)""#
+    private static let ARGUMENTS_REGEX = #"(value|placeholder)\(([^)]+)\)"#
+
+    private static let ARGUMENTS_REPLACE_1 = "(extension in Foundation):Swift.String.LocalizationValue.FormatArgument(storage: (extension in Foundation):Swift.String.LocalizationValue.FormatArgument.Storage."
+    private static let ARGUMENTS_REPLACE_2 = "(extension in Foundation):Swift.String.LocalizationValue.Placeholder."
+
+    private static let ARGUMENTS_VALUE = "value"
+    private static let ARGUMENTS_PLACEHOLDER = "placeholder"
+
+    /// Extract the key from the LocalizationValue description using a regular expression.
+    ///
+    /// - Returns: The extracted key or `nil`.
+    private func extractKeyRegex() -> String? {
+        let input = "\(self)"
+        return (try? NSRegularExpression(pattern: Self.KEY_REGEX))
+            .flatMap { $0.firstMatch(in: input,
+                                     range: NSRange(input.startIndex...,
+                                                    in: input)) }
+            .flatMap { Range($0.range(at: 1),
+                             in: input) }
+            .map { String(input[$0]) }
+    }
+
+    /// Extract the arguments from the LocalizationValue description using a regular expression.
+    ///
+    /// - Returns: The extracted arguments or an empty array.
+    private func extractArgumentsRegex() -> [Any] {
+        var extractedArgs: [Any] = []
+
+        let input = "\(self)"
+            .replacingOccurrences(of: Self.ARGUMENTS_REPLACE_1, with: "")
+            .replacingOccurrences(of: Self.ARGUMENTS_REPLACE_2, with: "")
+            .replacingOccurrences(of: "))", with: ")")
+
+        do {
+            let regex = try NSRegularExpression(pattern: Self.ARGUMENTS_REGEX)
+            let matches = regex.matches(in: input, range: NSRange(input.startIndex..., in: input))
+
+            for match in matches {
+                guard let typeRange = Range(match.range(at: 1), in: input),
+                      let valueRange = Range(match.range(at: 2), in: input) else { continue }
+
+                let type = String(input[typeRange])
+                var extractedValue = String(input[valueRange])
+
+                if type == Self.ARGUMENTS_VALUE {
+                    if let intValue = Int(extractedValue) {
+                        extractedArgs.append(intValue as CVarArg)
+                    } else if let uintValue = UInt(extractedValue) {
+                        extractedArgs.append(uintValue as CVarArg)
+                    } else if let floatValue = Float(extractedValue) {
+                        extractedArgs.append(floatValue as CVarArg)
+                    } else if let doubleValue = Double(extractedValue) {
+                        extractedArgs.append(doubleValue as CVarArg)
+                    } else {
+                        // Remove surrounding quotes if present
+                        extractedValue = extractedValue.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                        extractedArgs.append(extractedValue as CVarArg)
+                    }
+                } else if type == Self.ARGUMENTS_PLACEHOLDER {
+#if os(iOS)
+                    if #available(iOS 16, *),
+                       let placeholder = extractPlaceholderRegex(extractedValue) {
+                        extractedArgs.append(placeholder)
+                    }
+#elseif os(watchOS)
+                    if #available(watchOS 9, *),
+                       let placeholder = extractPlaceholderRegex(extractedValue) {
+                        extractedArgs.append(placeholder)
+                    }
+#elseif os(tvOS)
+                    if #available(tvOS 16, *),
+                       let placeholder = extractPlaceholderRegex(extractedValue) {
+                        extractedArgs.append(placeholder)
+                    }
+#elseif os(macOS)
+                    if #available(macOS 13, *),
+                       let placeholder = extractPlaceholderRegex(extractedValue) {
+                        extractedArgs.append(placeholder)
+                    }
+#endif
+                }
+            }
+        } catch {
+            // no-op
+        }
+
+        return extractedArgs
+    }
+
+    /// Cast the provided string value to String.LocalizationValue.Placeholder if possible
+    ///
+    /// - Parameter value: The string value corresponding to a Placeholder enum value.
+    /// - Returns: The LocalizationValue.Placeholder enum value, `nil` if extraction is not possible.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    private func extractPlaceholderRegex(_ value: String) -> String.LocalizationValue.Placeholder? {
+        switch value {
+        case "object":
+            return String.LocalizationValue.Placeholder.object
+        case "int":
+            return String.LocalizationValue.Placeholder.int
+        case "uint":
+            return String.LocalizationValue.Placeholder.uint
+        case "float":
+            return String.LocalizationValue.Placeholder.float
+        case "double":
+            return String.LocalizationValue.Placeholder.double
+        default:
+            return nil
+        }
+    }
+}
+
+extension Bundle {
+    /// Return a Bundle instance based on the value of the
+    /// `LocalizedStringResource.BundleDescription` enum.
+    ///
+    /// - Parameter description: The `LocalizedStringResource.BundleDescription`
+    /// enum value.
+    /// - Returns: The `Bundle` instance, `nil` if it cannot be constructed.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    internal static func from(description: LocalizedStringResource.BundleDescription) -> Bundle? {
+        switch description {
+        case .atURL(let url):
+            return Bundle(url: url)
+        case .forClass(let aClass):
+            return Bundle(for: aClass)
+        case .main:
+            return Bundle.main
+        @unknown default:
+            return nil
+        }
+    }
+}

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 /// Partially mocked URLSessionDataTask and URLSession classes so that we can test how
 /// Transifex behaves on certain server responses.
-class URLSessionDataTaskMock: URLSessionDataTask {
+class URLSessionDataTaskMock: URLSessionDataTask, @unchecked Sendable {
     private let closure: () -> Void
 
     init(closure: @escaping () -> Void) {
@@ -22,7 +22,7 @@ struct MockResponse {
     var error : Error?
 }
 
-class URLSessionMock: URLSession {
+class URLSessionMock: URLSession, @unchecked Sendable {
     typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
 
     var mockResponses : [MockResponse]?
@@ -1117,6 +1117,51 @@ final class TransifexTests: XCTestCase {
             ]
         )
     }
+    
+    func testLocalizationValueExtraction() {
+        let localizationValue: String.LocalizationValue = "test"
+        let extracted1Reflection = localizationValue.extract(.reflection)
+        let extracted1Regex = localizationValue.extract(.regex)
+
+        XCTAssertEqual(extracted1Reflection.key, "test")
+        XCTAssertEqual(extracted1Reflection.key, extracted1Regex.key)
+
+        let localizationValueWithArgs: String.LocalizationValue = "test \(1) \("string")"
+        let extracted2Reflection = localizationValueWithArgs.extract(.reflection)
+        let extracted2Regex = localizationValueWithArgs.extract(.regex)
+
+        XCTAssertEqual(extracted2Reflection.key, "test %lld %@")
+        XCTAssertEqual(extracted2Reflection.key, extracted2Regex.key)
+        XCTAssertEqual(extracted2Reflection.args.count, 2)
+        XCTAssertEqual(extracted2Reflection.args.count, extracted2Regex.args.count)
+        XCTAssertEqual(extracted2Reflection.args[0] as! Int64, 1)
+        // Reflection returns Int64 types for numbers while regular expression
+        // returns Int
+        XCTAssertTrue(extracted2Reflection.args[0] as! Int64 == extracted2Regex.args[0] as! Int)
+        XCTAssertEqual(extracted2Reflection.args[1] as! String, "string")
+        XCTAssertEqual(extracted2Reflection.args[1] as! String, extracted2Regex.args[1] as! String)
+
+        let localizationValueWithArgsAndPlaceholder: String.LocalizationValue = "test \(1) \(placeholder: .int) \("test")"
+        let extracted3Reflection = localizationValueWithArgsAndPlaceholder.extract(.reflection)
+        let extracted3Regex = localizationValueWithArgsAndPlaceholder.extract(.regex)
+
+        var options = String.LocalizationOptions()
+        options.replacements = [12]
+
+        let argsReflection = extracted3Reflection.combinedArgs(with: options)
+        let argsRegex = extracted3Regex.combinedArgs(with: options)
+
+        XCTAssertEqual(argsReflection.count, 3)
+        XCTAssertEqual(argsReflection.count, argsRegex.count)
+        XCTAssertEqual(argsReflection[0] as! Int64, 1)
+        // Reflection returns Int64 types for numbers while regular expression
+        // returns Int
+        XCTAssertTrue(argsReflection[0] as! Int64 == argsRegex[0] as! Int)
+        XCTAssertEqual(argsReflection[1] as! Int, 12)
+        XCTAssertEqual(argsReflection[1] as! Int, argsRegex[1] as! Int)
+        XCTAssertEqual(argsReflection[2] as! String, "test")
+        XCTAssertEqual(argsReflection[2] as! String, argsRegex[2] as! String)
+    }
 
     static var allTests = [
         ("testDuplicateLocaleFiltering", testDuplicateLocaleFiltering),
@@ -1156,5 +1201,6 @@ final class TransifexTests: XCTestCase {
         ("testXMLPluralParserSimpleSubstitutionsStringsDictAlt", testXMLPluralParserSimpleSubstitutionsStringsDictAlt),
         ("testXMLPluralParserDeviceAndSubstitutions", testXMLPluralParserDeviceAndSubstitutions),
         ("testXMLDeviceSubstitutionSpecial", testXMLDeviceSubstitutionSpecial),
+        ("testLocalizationValueExtraction", testLocalizationValueExtraction),
     ]
 }


### PR DESCRIPTION
### Support for `String.init(localized:...)` methods

* Implement support for `String.init(localized:...)` methods via
replacing the Swift struct initializers and performing reflection to
acquire the underlying `key` and `arguments` properties of the
`LocalizationValue` struct.
* Adds unit tests.
* Updates 'Limitations' section of `README.md` and adds a
'Supported localization methods' section.
* Updates `TXNativeExtensions.swift` file.
* Adds `PARAM_BUNDLE_KEY` to `Swizzler` in order to point to the proper
bundle for the `BypassLocalizer` class.
* Improves `BypassLocalizer` class logic.
* Exposes new public getters on `TXNative` class.
* Offers the choice to switch between Reflection and Regular Expression
extraction type when extracting the properties of the
`LocalizationValue` struct.

---

### Bump version to 2.0.8

* Bumps version to 2.0.8.
* Updates CHANGELOG with the changes implemented for 2.0.8.