### PR TITLE
Custom authorization key and builder initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,3 +164,13 @@ logic now normalizes the locale name to match the format that iOS accepts.
 updating the 'Limitations' section.
 * Refactors `BypassLocalizer` class.
 * Updates `TXNativeExtensions.swift`.
+
+## Transifex iOS SDK 2.0.9
+
+*December 12, 2025*
+
+* Allows SDK to be initialized using a builder pattern (`TXNativeBuilder`).
+* Deprecates existing SDK initialization methods in favor of the builder
+approach.
+* Supports overriding the authorization HTTP header key using the builder
+pattern.

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ import Transifex
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        TXNative.initialize(
-            locales: TXLocaleState(sourceLocale: "en",
-                                   appLocales: ["en", "el", "fr"]),
-            token: "<transifex_token>"
-        )
+        TXNativeBuilder()
+            .setLocales(TXLocaleState(sourceLocale: "en",
+                                      appLocales: ["en", "el", "fr"]))
+            .setToken("<transifex_token>")
+            .build()
 
         return true
     }
@@ -76,16 +76,16 @@ import Transifex
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        TXNative.initialize(
-            locales: TXLocaleState(sourceLocale: "en",
-                                   appLocales: ["en", "el", "fr"]),
-            token: "<transifex_token>",
-            secret: "<transifex_secret>",
-            missingPolicy: TXCompositePolicy(
+        TXNativeBuilder()
+            .setLocales(TXLocaleState(sourceLocale: "en",
+                                   appLocales: ["en", "el", "fr"]))
+            .setToken("<transifex_token>")
+            .setSecret("<transifex_secret>")
+            .setMissingPolicy(TXCompositePolicy(
                 TXPseudoTranslationPolicy(),
                 TXWrappedStringPolicy(start: "[", end: "]")
-            )
-        )
+            ))
+            .build()
 
         /// Optional: Fetch translations on launch
         TXNative.fetchTranslations()
@@ -134,18 +134,12 @@ If you are interested in setting up the SDK for your application extensions as w
         wrappedStringPolicy
     ]];
 
-    [TXNative initializeWithLocales:localeState
-                              token:@"<transifex_token>"
-                             secret:@"<transifex_secret>"
-                            cdsHost:nil
-                            session:nil
-                              cache:nil
-                      missingPolicy:compositePolicy
-                        errorPolicy:nil
-                  renderingStrategy:TXRenderingStategyPlatform
-                             logger:nil
-                         filterTags:nil
-                       filterStatus:nil];
+    [[[[[TXNativeBuilder.new
+         setLocales:localeState]
+         setToken:@"<transifex_token>"]
+         setSecret:@"<transifex_secret>"]
+         setMissingPolicy:compositePolicy]
+         build];
 
     /// Optional: Fetch translations on launch
     [TXNative fetchTranslations:nil
@@ -155,26 +149,6 @@ If you are interested in setting up the SDK for your application extensions as w
 
     return YES;
 }
-```
-
-### Alternative initialization
-
-If you want your application to make use of the default behavior, you can initialize the
-SDK using a simpler initilization method:
-
-#### Swift
-
-```swift
-TXNative.initialize(
-    locales: localeState,
-    token: "<transifex_token>"
-)
-```
-#### Objective-C
-
-```objc
-[TXNative initializeWithLocales:localeState
-                          token:@"<transifex_token>"];
 ```
 
 ### Supported localization methods
@@ -281,8 +255,10 @@ let locales = TXLocaleState(sourceLocale: "en",
                             appLocales: ["en", "el"],
                             currentLocaleProvider: CustomLocaleProvider())
 
-TXNative.initialize(locales: locales,
-                    token: "<token>")
+TXNativeBuilder()
+    .setLocales(locales)
+    .setToken("<token>")
+    .build()
 ```
 
 Objective-C example:
@@ -306,8 +282,10 @@ TXLocaleState *locales = [[TXLocaleState alloc] initWithSourceLocale:@"en"
                                                           appLocales:@[@"en", @"el"]
                                                currentLocaleProvider:customLocale];
 
-[TXNative initializeWithLocales:locales
-                          token:@"<token>"];
+[[[TXNativeBuilder.new
+   setLocales:locales]
+   setToken:@"<token>"]
+   build];
 ```
 
 It is worth noting that the iOS SDK manages an internal cache of translations in the file system of the translations fetched over-the-air.

--- a/Sources/Transifex/CDSHandler.swift
+++ b/Sources/Transifex/CDSHandler.swift
@@ -179,6 +179,9 @@ struct CDSConfiguration {
     var filterTags: [String] = []
     /// Fetch only strings matching translation status: reviewed,proofread,finalized
     var filterStatus: String? = nil
+    /// Optional value used for the HTTP header key that passes the `token` and the `secret` to
+    /// the `cdsHost`. If `nil`, the `Authorization` key will be used.
+    var customAuthorizationHeaderKey: String? = nil
 }
 
 /// Handles communication with the Content Delivery Service.
@@ -821,12 +824,13 @@ failed: \(details.failed)
             "X-NATIVE-SDK": "mobile/ios/\(TXNative.version)",
             "Accept-version": "v2"
         ]
+        let authorizationKey = configuration.customAuthorizationHeaderKey ?? "Authorization"
         if withSecret == true,
            let secret = configuration.secret {
-            headers["Authorization"] = "Bearer \(configuration.token):\(secret)"
+            headers[authorizationKey] = "Bearer \(configuration.token):\(secret)"
         }
         else {
-            headers["Authorization"] = "Bearer \(configuration.token)"
+            headers[authorizationKey] = "Bearer \(configuration.token)"
         }
         if let etag = etag {
             headers["If-None-Match"] = etag

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -161,6 +161,8 @@ class NativeCore : TranslationProvider {
     ///   - secret: the additional secret to use for pushing source content
     ///   - cdsHost: an optional host for the Content Delivery Service, defaults to the host provided by
     ///   Transifex
+    ///   - customAuthorizationHeaderKey: an optional value used for passing the `token` and the
+    ///   `secret` to the `cdsHost`. If `nil`, the `Authorization` key will be used.
     ///   - cache: the translation cache that holds the translations from the CDS
     ///   - session: Optional URLSession to be used for all the requests made to the CDS service. If
     ///   no session is provided, an ephemeral URLSession with no cache will be created and used
@@ -177,6 +179,7 @@ class NativeCore : TranslationProvider {
         token: String,
         secret: String?,
         cdsHost: String?,
+        customAuthorizationHeaderKey: String?,
         cache: TXCache?,
         session: URLSession? = nil,
         missingPolicy: TXMissingPolicy? = nil,
@@ -192,7 +195,8 @@ class NativeCore : TranslationProvider {
             secret: secret,
             cdsHost: cdsHost ?? CDSHandler.CDS_HOST,
             filterTags: filterTags,
-            filterStatus: filterStatus
+            filterStatus: filterStatus,
+            customAuthorizationHeaderKey: customAuthorizationHeaderKey
         )
         self.cdsHandler = CDSHandler(
             configuration: cdsConfiguration,
@@ -443,7 +447,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.8"
+    internal static let version = "2.0.9"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"
@@ -461,7 +465,7 @@ public final class TXNative : NSObject {
     public static let CDS_XML_ID_ATTRIBUTE = "id"
 
     /// An instance of the core class that handles all the work
-    private static var tx : NativeCore?
+   fileprivate static var tx : NativeCore?
     
     /// The available and current locales
     @objc
@@ -475,6 +479,8 @@ public final class TXNative : NSObject {
     ///
     /// Do not call initialize() twice without calling dispose() first to deconstruct the previous singleton
     /// instance.
+    ///
+    /// Deprecated: Please use `TXNativeBuilder` pattern instead.
     ///
     /// - Parameters:
     ///   - locales: keeps track of the available and current locales
@@ -495,6 +501,7 @@ public final class TXNative : NSObject {
     ///   fetched.
     ///   - filterStatus: An optional status so that only strings matching translation status are
     ///   fetched.
+    @available(*, deprecated, message: "Use TXNativeBuilder() instead")
     @objc
     public static func initialize(
         locales: TXLocaleState,
@@ -525,6 +532,7 @@ Initializing TXNative(
                         token: token,
                         secret: secret,
                         cdsHost: cdsHost,
+                        customAuthorizationHeaderKey: nil,
                         cache: cache,
                         session: session,
                         missingPolicy: missingPolicy,
@@ -541,9 +549,12 @@ Initializing TXNative(
     /// `initialize(locales:token:secret:cdsHost:session:cache:missingPolicy:errorPolicy:renderingStrategy:)`
     /// method.
     ///
+    /// Deprecated: Please use `TXNativeBuilder` pattern instead.
+    ///
     /// - Parameters:
     ///   - locales: keeps track of the available and current locales
     ///   - token: the Transifex token that can be used for retrieving translations from CDS
+    @available(*, deprecated, message: "Use TXNativeBuilder() instead")
     @objc
     public static func initialize(
         locales: TXLocaleState,
@@ -1004,5 +1015,159 @@ Initializing TXNative(
     public static func dispose() {
         Swizzler.deactivate()
         tx = nil
+    }
+}
+
+/// Builder class for passing only the properties necessary for the SDK initialization based on the developer
+/// needs and initializing the SDK.
+///
+/// Example:
+/// ```
+/// TXNativeBuilder()
+///     .setLocales(TXLocaleState(sourceLocale: "en",
+///                               appLocales: ["en"]))
+///     .setToken(token)
+///     .build()
+/// ```
+public final class TXNativeBuilder: NSObject {
+    private var locales: TXLocaleState?
+    private var token: String?
+    private var secret: String?
+    private var cdsHost: String?
+    private var customAuthorizationHeaderKey: String?
+    private var session: URLSession?
+    private var filterTags: [String] = []
+    private var filterStatus: String?
+    private var cache: TXCache?
+    private var missingPolicy: TXMissingPolicy?
+    private var errorPolicy: TXErrorPolicy?
+    private var renderingStrategy = TXRenderingStategy.platform
+
+    /// - Parameter locales: List of locale codes for the languages configured in the application.
+    /// - Returns: The builder instance
+    @objc
+    public func setLocales(_ locales: TXLocaleState) -> TXNativeBuilder {
+        self.locales = locales
+        return self
+    }
+
+    /// - Parameter token: API token to use for connecting to the CDS.
+    /// - Returns: The builder instance
+    @objc
+    public func setToken(_ token: String) -> TXNativeBuilder {
+        self.token = token
+        return self
+    }
+
+    /// - Parameter secret: Secret to use for pushing source content.
+    /// - Returns: The builder instance
+    @objc
+    public func setSecret(_ secret: String) -> TXNativeBuilder {
+        self.secret = secret
+        return self
+    }
+
+    /// - Parameter cdsHost: Host for the Content Delivery Service.
+    /// - Returns: The builder instance
+    @objc
+    public func setCDSHost(_ cdsHost: String) -> TXNativeBuilder {
+        self.cdsHost = cdsHost
+        return self
+    }
+    
+    /// - Parameter customAuthorizationHeaderKey: Value for the HTTP Header key used for
+    /// passing the `token` and the `secret` to the `cdsHost`.
+    /// - Returns: The builder instance
+    @objc
+    public func setCustomAuthorizationHeaderKey(_ customAuthorizationHeaderKey: String) -> TXNativeBuilder {
+        self.customAuthorizationHeaderKey = customAuthorizationHeaderKey
+        return self
+    }
+    
+    /// - Parameter session: URLSession to be used for all the requests made to the CDS service.
+    /// - Returns: The builder instance
+    @objc
+    public func setSession(_ session: URLSession) -> TXNativeBuilder {
+        self.session = session
+        return self
+    }
+
+    /// - Parameter filterTags: List of tags so that only strings that have all of the given tags are
+    ///   fetched.
+    /// - Returns: The builder instance
+    @objc
+    public func setFilterTags(_ filterTags: [String]) -> TXNativeBuilder {
+        self.filterTags = filterTags
+        return self
+    }
+
+    /// - Parameter filterStatus: Status so that only strings matching translation status are
+    ///   fetched.
+    /// - Returns: The builder instance
+    @objc
+    public func setFilterStatus(_ filterStatus: String) -> TXNativeBuilder {
+        self.filterStatus = filterStatus
+        return self
+    }
+
+    /// - Parameter cache: Translation cache that holds the translations from the CDS.
+    /// - Returns: The builder instance
+    @objc
+    public func setCache(_ cache: TXCache) -> TXNativeBuilder {
+        self.cache = cache
+        return self
+    }
+
+    /// - Parameter missingPolicy: Policy to use for returning strings when a translation is missing.
+    /// - Returns: The builder instance
+    @objc
+    public func setMissingPolicy(_ missingPolicy: TXMissingPolicy) -> TXNativeBuilder {
+        self.missingPolicy = missingPolicy
+        return self
+    }
+
+    /// - Parameter errorPolicy: Policy to determine how to handle rendering errors.
+    /// - Returns: The builder instance
+    @objc
+    public func setErrorPolicy(_ errorPolicy: TXErrorPolicy) -> TXNativeBuilder {
+        self.errorPolicy = errorPolicy
+        return self
+    }
+
+    /// - Parameter renderingStrategy: Strategy to be used when rendering the final string.
+    /// - Returns: The builder instance
+    @objc
+    public func setRenderingStrategy(_ renderingStrategy: TXRenderingStategy) -> TXNativeBuilder {
+        self.renderingStrategy = renderingStrategy
+        return self
+    }
+
+    /// Initializes the SDK based on the properties that were passed to the builder's setter methods before
+    /// hand.
+    ///
+    /// - Returns: True if the initialization was successful, false if either the `locales` or `token`
+    /// properties are missing or if the SDK has been already initialized.
+    @objc
+    @discardableResult
+    public func build() -> Bool {
+        guard let locales = locales,
+              let token = token,
+              TXNative.tx == nil else {
+            return false
+        }
+
+        TXNative.tx = NativeCore(locales: locales,
+                                 token: token,
+                                 secret: secret,
+                                 cdsHost: cdsHost,
+                                 customAuthorizationHeaderKey: customAuthorizationHeaderKey,
+                                 cache: cache,
+                                 session: session,
+                                 missingPolicy: missingPolicy,
+                                 errorPolicy: errorPolicy,
+                                 renderingStrategy: renderingStrategy,
+                                 filterTags: filterTags,
+                                 filterStatus: filterStatus)
+        return true
     }
 }

--- a/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
+++ b/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
@@ -97,22 +97,40 @@
                                                                 appLocales:@[ @"el" ]
                                                      currentLocaleProvider:mockLocaleProvider];
 
-    [TXNative initializeWithLocales:localeState
-                              token:@"<token>"
-                             secret:nil
-                            cdsHost:nil
-                            session:nil
-                              cache:memoryCache
-                      missingPolicy:nil
-                        errorPolicy:nil
-                  renderingStrategy:TXRenderingStategyPlatform
-                         filterTags:nil
-                       filterStatus:nil];
+    [[[[TXNativeBuilder.new
+        setLocales:localeState]
+        setToken:@"<token>"]
+        setCache:memoryCache]
+        build];
 
     NSString *string = [NSBundle.mainBundle localizedAttributedStringForKey:@"a"
                                                                       value:nil
                                                                       table:nil].string;
     XCTAssertEqualObjects(string, @"α");
+
+    [TXNative dispose];
+}
+
+- (void)testBuilder {
+    MockLocaleProvider *mockLocaleProvider = [MockLocaleProvider.alloc initWithMockLocaleCode:@"el"];
+    TXLocaleState *locales = [TXLocaleState.alloc initWithSourceLocale:@"en"
+                                                            appLocales:@[ @"el" ]
+                                                 currentLocaleProvider:mockLocaleProvider];
+
+    XCTAssertFalse([TXNativeBuilder.new build]);
+
+    XCTAssertFalse([[TXNativeBuilder.new
+                     setToken:@"token"]
+                     build]);
+
+    XCTAssertFalse([[TXNativeBuilder.new
+                     setLocales:locales]
+                     build]);
+
+    XCTAssertTrue([[[TXNativeBuilder.new
+                     setLocales:locales]
+                     setToken:@"token"]
+                     build]);
 
     [TXNative dispose];
 }

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -285,10 +285,12 @@ final class TransifexTests: XCTestCase {
 
         let localeState = TXLocaleState(sourceLocale: "en",
                                         appLocales: ["en"])
-        TXNative.initialize(locales: localeState,
-                            token: Self.testToken,
-                            session: urlSession,
-                            filterStatus: "translated")
+        TXNativeBuilder()
+            .setLocales(localeState)
+            .setToken(Self.testToken)
+            .setSession(urlSession)
+            .setFilterStatus("translated")
+            .build()
 
         let expectation1 = self.expectation(description: "Waiting for translated translations to be fetched")
         var translationErrors : [Error]? = nil
@@ -344,10 +346,12 @@ final class TransifexTests: XCTestCase {
 
         let localeState = TXLocaleState(sourceLocale: "en",
                                         appLocales: ["en"])
-        TXNative.initialize(locales: localeState,
-                            token: Self.testToken,
-                            session: urlSession,
-                            filterTags: ["ios"])
+        TXNativeBuilder()
+            .setLocales(localeState)
+            .setToken(Self.testToken)
+            .setSession(urlSession)
+            .setFilterTags(["ios"])
+            .build()
 
         let expectation1 = self.expectation(description: "Waiting for iOS translations to be fetched")
         var translationErrors : [Error]? = nil
@@ -703,10 +707,11 @@ final class TransifexTests: XCTestCase {
         let memoryCache =  TXMemoryCache()
         memoryCache.update(translations: existingTranslations)
 
-        TXNative.initialize(locales: localeState,
-                            token: Self.testToken,
-                            cache: memoryCache,
-                            renderingStrategy: .platform)
+        TXNativeBuilder()
+            .setLocales(localeState)
+            .setToken(Self.testToken)
+            .setCache(memoryCache)
+            .build()
         
         XCTAssertEqual(NSLocalizedString("a", comment: ""), "α")
     }
@@ -834,10 +839,11 @@ final class TransifexTests: XCTestCase {
         let localeState = TXLocaleState(sourceLocale: "en",
                                         appLocales: ["fr"])
 
-        TXNative.initialize(locales: localeState,
-                            token: Self.testToken,
-                            renderingStrategy: .platform)
-        
+        TXNativeBuilder()
+            .setLocales(localeState)
+            .setToken(Self.testToken)
+            .build()
+
         let result = TXNative.localizedString(format: "test", arguments: [1,2] as [CVarArg])
         
         XCTAssertNotNil(result)
@@ -848,10 +854,12 @@ final class TransifexTests: XCTestCase {
         let localeState = TXLocaleState(sourceLocale: "en",
                                         appLocales: ["fr"])
         
-        TXNative.initialize(locales: localeState,
-                            token: Self.testToken,
-                            errorPolicy: MockErrorPolicy(),
-                            renderingStrategy: .icu)
+        TXNativeBuilder()
+            .setLocales(localeState)
+            .setToken(Self.testToken)
+            .setErrorPolicy(MockErrorPolicy())
+            .setRenderingStrategy(.icu)
+            .build()
         
         let result = TXNative.translate(sourceString: "source string", params: [:], context: nil)
 
@@ -863,10 +871,12 @@ final class TransifexTests: XCTestCase {
         let localeState = TXLocaleState(sourceLocale: "en",
                                         appLocales: ["fr"])
         
-        TXNative.initialize(locales: localeState,
-                            token: Self.testToken,
-                            errorPolicy: MockErrorPolicyException(),
-                            renderingStrategy: .icu)
+        TXNativeBuilder()
+            .setLocales(localeState)
+            .setToken(Self.testToken)
+            .setErrorPolicy(MockErrorPolicyException())
+            .setRenderingStrategy(.icu)
+            .build()
         
         let result = TXNative.translate(sourceString: "source string", params: [:], context: nil)
 
@@ -943,9 +953,11 @@ final class TransifexTests: XCTestCase {
         let memoryCache =  TXMemoryCache()
         memoryCache.update(translations: existingTranslations)
         
-        TXNative.initialize(locales: localeState,
-                            token: Self.testToken,
-                            cache: memoryCache)
+        TXNativeBuilder()
+            .setLocales(localeState)
+            .setToken(Self.testToken)
+            .setCache(memoryCache)
+            .build()
         
         let result = TXNative.translate(sourceString: sourceStringTest,
                                         params: [:],
@@ -1163,6 +1175,24 @@ final class TransifexTests: XCTestCase {
         XCTAssertEqual(argsReflection[2] as! String, argsRegex[2] as! String)
     }
 
+    func testBuilder() {
+        let locales = TXLocaleState(sourceLocale: "en",
+                                    appLocales: ["en"])
+
+        XCTAssertFalse(TXNativeBuilder()
+            .setLocales(locales)
+            .build())
+
+        XCTAssertFalse(TXNativeBuilder()
+            .setToken("token")
+            .build())
+
+        XCTAssertTrue(TXNativeBuilder()
+            .setLocales(locales)
+            .setToken("token")
+            .build())
+    }
+
     static var allTests = [
         ("testDuplicateLocaleFiltering", testDuplicateLocaleFiltering),
         ("testCurrentLocaleProvider", testCurrentLocaleProvider),
@@ -1202,5 +1232,6 @@ final class TransifexTests: XCTestCase {
         ("testXMLPluralParserDeviceAndSubstitutions", testXMLPluralParserDeviceAndSubstitutions),
         ("testXMLDeviceSubstitutionSpecial", testXMLDeviceSubstitutionSpecial),
         ("testLocalizationValueExtraction", testLocalizationValueExtraction),
+        ("testBuilder", testBuilder)
     ]
 }


### PR DESCRIPTION
* SDK can now be initialized using a builder pattern (`TXNativeBuilder`).
* Existing SDK initialization methods have been marked as deprecated.
* Supports a custom authorization header key to be offered when using the builder SDK initilization.
* README has been updated.
* Unit tests implemented.
* Version has been bumped to 2.0.9.