### PR TITLE
Feature/2.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,3 +174,12 @@ updating the 'Limitations' section.
 approach.
 * Supports overriding the authorization HTTP header key using the builder
 pattern.
+
+## Transifex iOS SDK 2.0.10
+
+*January 12, 2025*
+
+* Improves unit test suite.
+* Bumps supported macOS version from 10.13 to 10.14.
+* Improves `fetchTranslations` threading logic.
+* Introduces `disableSwizzling()` method in `TXNativeBuilder`.

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .iOS(.v12),
         .watchOS(.v4),
         .tvOS(.v12),
-        .macOS(.v10_13)
+        .macOS(.v10_14)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The full SDK documentation is available at [https://transifex.github.io/transife
 
 | Swift           | Xcode            | Platforms                                            |
 |-----------------|------------------|------------------------------------------------------|
-| Swift 5.3       | Xcode 15.4       | iOS 12.0, watchOS 4.0, tvOS 12.0, macOS 10.13        |
+| Swift 5.3       | Xcode 15.4       | iOS 12.0, watchOS 4.0, tvOS 12.0, macOS 10.14        |
 
 ## Usage
 

--- a/Sources/Transifex/CDSHandler.swift
+++ b/Sources/Transifex/CDSHandler.swift
@@ -294,6 +294,8 @@ class CDSHandler {
 
     private typealias CDSPullRequestResult = Result<TXLocaleStrings, TXCDSError>
 
+    private let aggregationQueue = DispatchQueue(label: "com.transifex.native.cds")
+
     /// The url session to be used for the requests to the CDS, defaults to an ephemeral URLSession with
     /// a disabled URL cache.
     let session: URLSession
@@ -379,21 +381,19 @@ class CDSHandler {
             performFetch(retryCount: 0,
                          code: code,
                          request: requestByLocale) { [weak self] result in
-                guard let _ = self else {
-                    return
-                }
+                self?.aggregationQueue.async {
+                    requestsFinished += 1
 
-                requestsFinished += 1
+                    switch result {
+                    case .success(let localeStrings):
+                        translationsByLocale[code] = localeStrings
+                    case .failure(let error):
+                        errors.append(error)
+                    }
 
-                switch result {
-                case .success(let localeStrings):
-                    translationsByLocale[code] = localeStrings
-                case .failure(let error):
-                    errors.append(error)
-                }
-
-                if requestsFinished == totalRequests {
-                    completionHandler(translationsByLocale, errors)
+                    if requestsFinished == totalRequests {
+                        completionHandler(translationsByLocale, errors)
+                    }
                 }
             }
         }

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -174,6 +174,7 @@ class NativeCore : TranslationProvider {
     ///   fetched.
     ///   - filterStatus: An optional status so that only strings matching translation status are
     ///   fetched.
+    ///   - swizzling: Control whether the internal swizzling logic will be activated or not (default: true).
     init(
         locales: TXLocaleState,
         token: String,
@@ -186,7 +187,8 @@ class NativeCore : TranslationProvider {
         errorPolicy: TXErrorPolicy? = nil,
         renderingStrategy : TXRenderingStategy,
         filterTags: [String] = [],
-        filterStatus: String? = nil
+        filterStatus: String? = nil,
+        swizzling: Bool = true
     ) {
         self.locales = locales
         let cdsConfiguration = CDSConfiguration(
@@ -207,8 +209,9 @@ class NativeCore : TranslationProvider {
         self.errorPolicy = errorPolicy ?? TXRenderedSourceErrorPolicy()
         self.renderingStrategy = renderingStrategy
         self.bypassLocalizer = BypassLocalizer(with: locales.sourceLocale)
-        
-        Swizzler.activate(translationProvider: self)
+        if swizzling {
+            Swizzler.activate(translationProvider: self)
+        }
     }
     
     /// Fetch translations from CDS and store them in the cache.
@@ -1042,6 +1045,7 @@ public final class TXNativeBuilder: NSObject {
     private var missingPolicy: TXMissingPolicy?
     private var errorPolicy: TXErrorPolicy?
     private var renderingStrategy = TXRenderingStategy.platform
+    private var swizzling = true
 
     /// - Parameter locales: List of locale codes for the languages configured in the application.
     /// - Returns: The builder instance
@@ -1142,6 +1146,15 @@ public final class TXNativeBuilder: NSObject {
         return self
     }
 
+    /// Disables swizzling (enabled by default).
+    ///
+    /// - Returns: The builder instance
+    @objc
+    public func disableSwizzling() -> TXNativeBuilder {
+        self.swizzling = false
+        return self
+    }
+
     /// Initializes the SDK based on the properties that were passed to the builder's setter methods before
     /// hand.
     ///
@@ -1167,7 +1180,8 @@ public final class TXNativeBuilder: NSObject {
                                  errorPolicy: errorPolicy,
                                  renderingStrategy: renderingStrategy,
                                  filterTags: filterTags,
-                                 filterStatus: filterStatus)
+                                 filterStatus: filterStatus,
+                                 swizzling: swizzling)
         return true
     }
 }

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -450,7 +450,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.9"
+    internal static let version = "2.0.10"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -1196,6 +1196,45 @@ final class TransifexTests: XCTestCase {
             .setToken("token")
             .build())
     }
+    
+    func testDisabledSwizzling() {
+        let existingTranslations: TXTranslations = [
+            "en": [
+                "a": [ "string": "a" ],
+            ],
+            "el": [
+                "a": [ "string": "α" ],
+            ]
+        ]
+
+        let locales = TXLocaleState(sourceLocale: "en",
+                                    appLocales: ["el"],
+                                    currentLocaleProvider: MockLocaleProvider("el"))
+
+        let memoryCache =  TXMemoryCache()
+        memoryCache.update(translations: existingTranslations)
+
+        TXNativeBuilder()
+            .setLocales(locales)
+            .setToken(Self.testToken)
+            .setCache(memoryCache)
+            .build()
+
+        XCTAssertEqual(NSLocalizedString("a", comment: ""), "α")
+
+        TXNative.dispose()
+
+        TXNativeBuilder()
+            .setLocales(locales)
+            .setToken(Self.testToken)
+            .setCache(memoryCache)
+            .disableSwizzling()
+            .build()
+
+        XCTAssertNotEqual(NSLocalizedString("a", comment: ""), "α")
+        XCTAssertEqual(TXNative.t("a"), "α")
+        XCTAssertEqual(TXNative.translate(sourceString: "a", params: [:], context: nil), "α")
+    }
 
     static var allTests = [
         ("testDuplicateLocaleFiltering", testDuplicateLocaleFiltering),

--- a/Tests/TransifexTests/TransifexTests.swift
+++ b/Tests/TransifexTests/TransifexTests.swift
@@ -1,20 +1,6 @@
 import XCTest
 @testable import Transifex
 
-/// Partially mocked URLSessionDataTask and URLSession classes so that we can test how
-/// Transifex behaves on certain server responses.
-class URLSessionDataTaskMock: URLSessionDataTask, @unchecked Sendable {
-    private let closure: () -> Void
-
-    init(closure: @escaping () -> Void) {
-        self.closure = closure
-    }
-
-    override func resume() {
-        closure()
-    }
-}
-
 struct MockResponse {
     var url : URL
     var data : Data?
@@ -22,40 +8,62 @@ struct MockResponse {
     var error : Error?
 }
 
-class URLSessionMock: URLSession, @unchecked Sendable {
-    typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
+final class URLProtocolMock: URLProtocol {
+    static var mockResponses: [MockResponse] = []
+    static var mockResponseIndex = 0
 
-    var mockResponses : [MockResponse]?
-    var mockResponseIndex = 0
-    
-    override init() { }
-    
-    override func dataTask(
-        with request: URLRequest,
-        completionHandler: @escaping CompletionHandler
-    ) -> URLSessionDataTask {
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
         guard
             let requestURL = request.url,
-            let mockResponse = mockResponses?[mockResponseIndex],
-            mockResponse.url == requestURL else {
-            return URLSessionDataTaskMock {
-                completionHandler(nil, nil, nil)
-            }
+            URLProtocolMock.mockResponseIndex < URLProtocolMock.mockResponses.count else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
         }
-        
-        mockResponseIndex += 1
-        
-        let data = mockResponse.data
-        let error = mockResponse.error
-        
-        return URLSessionDataTaskMock {
-            let response = HTTPURLResponse(url: requestURL,
-                                           statusCode: mockResponse.statusCode ?? 200,
-                                           httpVersion: nil,
-                                           headerFields: nil)
-            completionHandler(data, response, error)
+
+        let mockResponse = URLProtocolMock.mockResponses[URLProtocolMock.mockResponseIndex]
+        guard mockResponse.url == requestURL else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
         }
+
+        URLProtocolMock.mockResponseIndex += 1
+
+        if let error = mockResponse.error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+
+        let response = HTTPURLResponse(url: requestURL,
+                                       statusCode: mockResponse.statusCode ?? 200,
+                                       httpVersion: nil,
+                                       headerFields: nil) ?? URLResponse()
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+
+        if let data = mockResponse.data {
+            client?.urlProtocol(self, didLoad: data)
+        }
+
+        client?.urlProtocolDidFinishLoading(self)
     }
+
+    override func stopLoading() { }
+}
+
+func makeMockSession(responses: [MockResponse]) -> URLSession {
+    URLProtocolMock.mockResponses = responses
+    URLProtocolMock.mockResponseIndex = 0
+
+    let configuration: URLSessionConfiguration = .ephemeral
+    configuration.protocolClasses = [URLProtocolMock.self]
+    return URLSession(configuration: configuration)
 }
 
 class MockLocaleProvider : TXCurrentLocaleProvider {
@@ -277,11 +285,10 @@ final class TransifexTests: XCTestCase {
         let mockResponse2 = MockResponse(url: URL(string: "https://cds.svc.transifex.net/content/en?filter%5Bstatus%5D=reviewed")!,
                                          data: "{\"data\":{\"testkey3\":{\"string\":\"test string 3\"}}}".data(using: .utf8))
 
-        let urlSession = URLSessionMock()
-        urlSession.mockResponses = [
+        let urlSession = makeMockSession(responses: [
             mockResponse1,
             mockResponse2
-        ]
+        ])
 
         let localeState = TXLocaleState(sourceLocale: "en",
                                         appLocales: ["en"])
@@ -339,10 +346,10 @@ final class TransifexTests: XCTestCase {
         let mockResponse2 = MockResponse(url: URL(string: "https://cds.svc.transifex.net/content/en?filter%5Btags%5D=android")!,
                                          data: "{\"data\":{\"testkey3\":{\"string\":\"test string 3\"}}}".data(using: .utf8))
 
-        let urlSession = URLSessionMock()
-        urlSession.mockResponses = [
+        let urlSession = makeMockSession(responses: [
             mockResponse1,
-            mockResponse2 ]
+            mockResponse2
+        ])
 
         let localeState = TXLocaleState(sourceLocale: "en",
                                         appLocales: ["en"])
@@ -400,11 +407,10 @@ final class TransifexTests: XCTestCase {
         let mockResponse2 = MockResponse(url: URL(string: "https://cds.svc.transifex.net/content/en?filter%5Bstatus%5D=reviewed")!,
                                          data: "{\"data\":{\"testkey3\":{\"string\":\"test string 3\"}}}".data(using: .utf8))
 
-        let urlSession = URLSessionMock()
-        urlSession.mockResponses = [
+        let urlSession = makeMockSession(responses: [
             mockResponse1,
             mockResponse2
-        ]
+        ])
 
         let cdsConfiguration = CDSConfiguration(localeCodes: [ "en" ],
                                                 token: Self.testToken)
@@ -458,11 +464,10 @@ final class TransifexTests: XCTestCase {
         let mockResponse2 = MockResponse(url: URL(string: "https://cds.svc.transifex.net/content/en?filter%5Btags%5D=android")!,
                                          data: "{\"data\":{\"testkey3\":{\"string\":\"test string 3\"}}}".data(using: .utf8))
 
-        let urlSession = URLSessionMock()
-        urlSession.mockResponses = [
+        let urlSession = makeMockSession(responses: [
             mockResponse1,
             mockResponse2
-        ]
+        ])
 
         let cdsConfiguration = CDSConfiguration(localeCodes: [ "en" ],
                                                 token: Self.testToken)
@@ -520,8 +525,7 @@ final class TransifexTests: XCTestCase {
                                         data: mockResponseData,
                                         statusCode: 200)
         
-        let urlSession = URLSessionMock()
-        urlSession.mockResponses = [mockResponse]
+        let urlSession = makeMockSession(responses: [mockResponse])
         
         let cdsConfiguration = CDSConfiguration(localeCodes: [ "en" ],
                                                 token: Self.testToken)
@@ -557,12 +561,11 @@ final class TransifexTests: XCTestCase {
                                              data: mockResponseData,
                                              statusCode: 200)
         
-        let urlSession = URLSessionMock()
-        urlSession.mockResponses = [
+        let urlSession = makeMockSession(responses: [
             mockResponseNotReady,
             mockResponseNotReady,
             mockResponseReady
-        ]
+        ])
         
         let cdsConfiguration = CDSConfiguration(localeCodes: [ "en" ],
                                                 token: Self.testToken)
@@ -594,7 +597,7 @@ final class TransifexTests: XCTestCase {
                            characterLimit: 0)
         ]
         
-        let expectedDataString = "{\"data\":{\"id\":\"123\",\"links\":{\"job\":\"/jobs/content/456\"}}}"
+        let expectedDataString = "{\"data\":{\"id\":\"123\",\"links\":{\"job\":\"jobs/content/456\"}}}"
         let expectedURL = URL(string: "https://cds.svc.transifex.net/content")!
         
         let mockResponse = MockResponse(url: expectedURL,
@@ -608,8 +611,10 @@ final class TransifexTests: XCTestCase {
                                            data: expectedJobDataString.data(using: .utf8),
                                            statusCode: 200)
         
-        let urlSession = URLSessionMock()
-        urlSession.mockResponses = [ mockResponse, mockJobResponse ]
+        let urlSession = makeMockSession(responses: [
+            mockResponse,
+            mockJobResponse
+        ])
         let cdsConfiguration = CDSConfiguration(localeCodes: [ "en" ],
                                                 token: Self.testToken)
         let cdsHandler = CDSHandler(configuration: cdsConfiguration,
@@ -621,7 +626,7 @@ final class TransifexTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(timeout: 1.0) { (error) in
+        waitForExpectations(timeout: 3.0) { (error) in
             XCTAssertTrue(pushResult)
         }
     }
@@ -635,7 +640,7 @@ final class TransifexTests: XCTestCase {
                            characterLimit: 0)
         ]
         
-        let expectedDataString = "{\"data\":{\"id\":\"123\",\"links\":{\"job\":\"/jobs/content/456\"}}}"
+        let expectedDataString = "{\"data\":{\"id\":\"123\",\"links\":{\"job\":\"jobs/content/456\"}}}"
         let expectedURL = URL(string: "https://cds.svc.transifex.net/content")!
         
         let mockResponse = MockResponse(url: expectedURL,
@@ -659,8 +664,7 @@ final class TransifexTests: XCTestCase {
                                                     data: expectedCompletedJobDataString.data(using: .utf8),
                                                     statusCode: 200)
         
-        let urlSession = URLSessionMock()
-        urlSession.mockResponses = [
+        let urlSession = makeMockSession(responses: [
             mockResponse,
             mockPendingJobResponse,
             mockPendingJobResponse,
@@ -673,7 +677,7 @@ final class TransifexTests: XCTestCase {
             mockProcessingJobResponse,
             mockProcessingJobResponse,
             mockCompletedJobResponse
-        ]
+        ])
         let cdsConfiguration = CDSConfiguration(localeCodes: [ "en" ],
                                                 token: Self.testToken)
         let cdsHandler = CDSHandler(configuration: cdsConfiguration,
@@ -685,7 +689,7 @@ final class TransifexTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(timeout: 1.0) { (error) in
+        waitForExpectations(timeout: 15.0) { (error) in
             XCTAssertTrue(pushResult)
         }
     }


### PR DESCRIPTION
* Uses a different approach when mocking the session for tests
* Bumps supported macOS version from 10.13 to 10.14
* Improves fetchTranslations threading logic
* Allows swizzling to be disabled in builder
* Bumps version to 2.0.10