### PR TITLE
Refactor localizedStringWithFormat: ObjC swizzling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,9 +177,17 @@ pattern.
 
 ## Transifex iOS SDK 2.0.10
 
-*January 12, 2025*
+*January 12, 2026*
 
 * Improves unit test suite.
 * Bumps supported macOS version from 10.13 to 10.14.
 * Improves `fetchTranslations` threading logic.
 * Introduces `disableSwizzling()` method in `TXNativeBuilder`.
+
+## Transifex iOS SDK 2.0.11
+
+*February 8, 2026
+
+* Improves Objective-C swizzling method, ensuring it does not crash when parsing
+the argument list (`swizzledLocalizedStringWithFormat:`).
+* Adds more unit tests.

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -450,7 +450,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.10"
+    internal static let version = "2.0.11"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Sources/Transifex/Swizzler.swift
+++ b/Sources/Transifex/Swizzler.swift
@@ -289,14 +289,7 @@ class Swizzler {
                 }
             case .char,
                  .cString,
-                 .object,
-                 .percent:
-                if let string = argument.value as? String {
-                    args.append(string)
-                }
-            // We include the invalid case, so that the error is visible in the
-            // UI.
-            case .invalid:
+                 .object:
                 if let string = argument.value as? String {
                     args.append(string)
                 }

--- a/Sources/TransifexObjCRuntime/TXNativeObjcSwizzler.m
+++ b/Sources/TransifexObjCRuntime/TXNativeObjcSwizzler.m
@@ -9,127 +9,201 @@
 #import <objc/runtime.h>
 #import "TXNativeObjcSwizzler.h"
 
-static const NSString *kInvalidConversionSpecifier = @"INVALID";
-
 static NSString *(^TXNativeObjcSwizzlerClosure)(NSString *, NSArray <id> *);
 
 @implementation NSString (TXNativeObjcSwizzler)
 
 + (instancetype)swizzledLocalizedStringWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2) {
-    // Match all %{something} specifiers in the format string via a regular
-    // expression.
-    //
-    // The regular expression matches any character combinations that start with
-    // the character '%' followed by at least one non-whitespace character (\S+)
-    NSString *regExPattern = @"\%\\S+";
-    NSError *error = nil;
-    NSRegularExpression *regex = [NSRegularExpression
-        regularExpressionWithPattern:regExPattern
-        options:0
-        error:&error];
-    
-    if (error) {
-        NSLog(@"%s Error: %@",
-              __PRETTY_FUNCTION__,
-              error);
-        
-        return TXNativeObjcSwizzlerClosure(format,
-                                           @[]);
-    }
-    
     va_list argumentList;
     va_start(argumentList, format);
-    
-    NSRange totalRange = NSMakeRange(0, format.length);
-    NSMutableArray <TXNativeObjcArgument *> *arguments = [NSMutableArray new];
-    
-    for (NSTextCheckingResult *match in [regex matchesInString:format
-                                                       options:0
-                                                         range:totalRange]) {
-        NSRange matchRange = match.range;
-        NSString *originalMatchString = [format substringWithRange:matchRange];
+    va_list originalArgs;
+    va_copy(originalArgs, argumentList);
 
-        // Look into what's after the % character
-        NSRange matchRangePlusOne = NSMakeRange(matchRange.location + 1,
-                                                matchRange.length - 1);
-        NSString *matchString = [format substringWithRange:matchRangePlusOne].lowercaseString;
+    // Strictly match conversion specs like: %[flags][width][.precision][length]conv
+    NSString *regExPattern = @"%(%|(?:[#+\\-0 ]*)(?:\\d+)?(?:\\.\\d+)?(?:hh|h|ll|l|j|z|t|L)?[@aAcCdDeEfFgGiIoOsSpuxX])";
+    NSRegularExpression *regex = [NSRegularExpression
+                                  regularExpressionWithPattern:regExPattern
+                                  options:0
+                                  error:nil];
+
+    if (!regex) {
+        NSString *original =
+            [self tx_originalLocalizedStringWithFormat:format
+                                                vaList:originalArgs];
+        va_end(originalArgs);
+        va_end(argumentList);
+        return original;
+    }
+
+    NSArray<NSTextCheckingResult *> *matches =
+        [regex matchesInString:format
+                       options:0
+                         range:NSMakeRange(0, format.length)];
+
+    // Sanity check: Ensure all % tokens are matched by the regex.
+    NSInteger percentCount = 0;
+    for (NSUInteger i = 0; i < format.length; i++) {
+        if ([format characterAtIndex:i] != '%') {
+            continue;
+        }
+        percentCount++;
+        if (i + 1 < format.length
+            && [format characterAtIndex:i + 1] == '%') { // skip second '%'
+            i++;
+        }
+    }
+
+    if (percentCount != matches.count) {
+        NSString *original =
+            [self tx_originalLocalizedStringWithFormat:format
+                                                vaList:originalArgs];
+        va_end(originalArgs);
+        va_end(argumentList);
+        return original;
+    }
+
+    NSMutableArray <TXNativeObjcArgument *> *arguments = [NSMutableArray new];
+    BOOL shouldFallback = NO;
+
+    for (NSTextCheckingResult *match in matches) {
+        NSString *originalMatchString = [format substringWithRange:match.range];
+
+        // Reject positional arguments and width/precision star.
+        if ([originalMatchString rangeOfString:@"$"].location != NSNotFound ||
+            [originalMatchString rangeOfString:@"*"].location != NSNotFound) {
+            shouldFallback = YES;
+            break;
+        }
+
+        // Extract the conversion character (last char)
+        unichar conv =
+            [originalMatchString characterAtIndex:originalMatchString.length - 1];
 
         TXNativeObjcArgument *arg = [TXNativeObjcArgument new];
 
-        // Integer (%d, %D)
-        if ([matchString containsString:@"d"]) {
-            int intObject = va_arg(argumentList, int);
-            arg.value = @(intObject);
-            arg.type = TXNativeObjcArgumentTypeInt;
+        switch (conv) {
+            // Integer (%d, %i)
+            case 'd': case 'i': {
+                // Reject length modifiers
+                if ([originalMatchString rangeOfString:@"h"].location != NSNotFound ||
+                    [originalMatchString rangeOfString:@"l"].location != NSNotFound ||
+                    [originalMatchString rangeOfString:@"j"].location != NSNotFound ||
+                    [originalMatchString rangeOfString:@"z"].location != NSNotFound ||
+                    [originalMatchString rangeOfString:@"t"].location != NSNotFound) {
+                    shouldFallback = YES;
+                    break;
+                }
+                int intObject = va_arg(argumentList, int);
+                arg.value = @(intObject);
+                arg.type = TXNativeObjcArgumentTypeInt;
+                break;
+            }
+            // Unsigned (%u)
+            case 'u': {
+                // Reject length modifiers
+                if ([originalMatchString rangeOfString:@"h"].location != NSNotFound ||
+                    [originalMatchString rangeOfString:@"l"].location != NSNotFound ||
+                    [originalMatchString rangeOfString:@"j"].location != NSNotFound ||
+                    [originalMatchString rangeOfString:@"z"].location != NSNotFound ||
+                    [originalMatchString rangeOfString:@"t"].location != NSNotFound) {
+                    shouldFallback = YES;
+                    break;
+                }
+                unsigned unsignedObject = va_arg(argumentList, unsigned);
+                arg.value = @(unsignedObject);
+                arg.type = TXNativeObjcArgumentTypeUnsigned;
+                break;
+            }
+            // Double (%e, %E, %g, %G, %a, %A, %f, %F)
+            case 'e': case 'E':
+            case 'g': case 'G':
+            case 'a': case 'A':
+            case 'f': case 'F': {
+                // Reject length modifiers except L (long double)
+                if ([originalMatchString rangeOfString:@"L"].location != NSNotFound) {
+                    shouldFallback = YES;
+                    break;
+                }
+                double doubleObject = va_arg(argumentList, double);
+                arg.value = @(doubleObject);
+                arg.type = TXNativeObjcArgumentTypeDouble;
+                break;
+            }
+            // Character (%c)
+            case 'c': {
+                int charObject = va_arg(argumentList, int);
+                arg.value = [NSString stringWithFormat:@"%c", charObject];
+                arg.type = TXNativeObjcArgumentTypeChar;
+                break;
+            }
+            // C String (%s)
+            case 's': {
+                char *charObject = va_arg(argumentList, char *);
+                if (!charObject) {
+                    arg.value = @"(null)";
+                }
+                else {
+                    arg.value = [NSString stringWithUTF8String:charObject];
+                }
+                arg.type = TXNativeObjcArgumentTypeCString;
+                break;
+            }
+            // Objective-C object (%@)
+            case '@': {
+                id obj = va_arg(argumentList, id);
+                arg.value = obj;
+                arg.type = TXNativeObjcArgumentTypeObject;
+                break;
+            }
+            // '%' character (%%)
+            case '%': {
+                // Percent literal has no argument to pass through.
+                continue;
+            }
+            default:
+                shouldFallback = YES;
+                break;
         }
-        // Unsigned (%u, %U)
-        else if ([matchString containsString:@"u"]) {
-            unsigned unsignedObject = va_arg(argumentList, unsigned);
-            arg.value = @(unsignedObject);
-            arg.type = TXNativeObjcArgumentTypeUnsigned;
+
+        if (shouldFallback) {
+            break;
         }
-        // Double (%e, %E, %g, %G, %a, %A, %f, %F)
-        else if ([matchString containsString:@"e"]
-                 || [matchString containsString:@"g"]
-                 || [matchString containsString:@"a"]
-                 || [matchString containsString:@"f"]) {
-            double doubleObject = va_arg(argumentList, double);
-            arg.value = @(doubleObject);
-            arg.type = TXNativeObjcArgumentTypeDouble;
-        }
-        // Character (%c, %C)
-        else if ([matchString containsString:@"c"]) {
-            int charObject = va_arg(argumentList, int);
-            NSString *stringObject = [NSString stringWithFormat:originalMatchString,
-                                      charObject];
-            arg.value = stringObject;
-            arg.type = TXNativeObjcArgumentTypeChar;
-        }
-        // C String (%s, %S)
-        else if ([matchString containsString:@"s"]) {
-            char *charObject = va_arg(argumentList, char *);
-            NSString *stringObject = [NSString stringWithUTF8String:charObject];
-            arg.value = stringObject;
-            arg.type = TXNativeObjcArgumentTypeCString;
-        }
-        // Objective-C object (%@)
-        else if ([matchString isEqualToString:@"@"]) {
-            NSString *stringObject = (NSString *)va_arg(argumentList, id);
-            arg.value = stringObject;
-            arg.type = TXNativeObjcArgumentTypeObject;
-        }
-        // '%' character (%%)
-        else if ([matchString isEqualToString:@"%"]){
-            arg.value = @"%";
-            arg.type = TXNativeObjcArgumentTypePercent;
-        }
-        // If there's a conversion specifier that the logic isn't handling yet,
-        // fallbak to an invalid string constant.
-        else {
-            arg.value = kInvalidConversionSpecifier;
-            arg.type = TXNativeObjcArgumentTypeInvalid;
-        }
-        
+
         [arguments addObject:arg];
-        
-        // Ignored conversion specifiers:
-        // %x, %X (hexademical)
-        // %o, %O (octal)
-        // %p (pointer)
-        //
-        // Other specifiers / modifiers that need to be tested:
-        // * Positional specifiers (e.g. %1$@, %2%s etc)
-        // * Length modifiers (e.g. %llu, %ld etc)
-        //
-        // Ref:
-        // * https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFStrings/formatSpecifiers.html
-        // * https://pubs.opengroup.org/onlinepubs/009695399/functions/printf.html
     }
-    
+
+    // Perform a local-capture of the closure to avoid race conditions.
+    NSString *(^closure)(NSString *, NSArray<id> *) = TXNativeObjcSwizzlerClosure;
+
+    if (shouldFallback || closure == nil) {
+        NSString *original =
+            [self tx_originalLocalizedStringWithFormat:format
+                                                vaList:originalArgs];
+        va_end(originalArgs);
+        va_end(argumentList);
+        return original;
+    }
+
+    va_end(originalArgs);
     va_end(argumentList);
-    
-    return TXNativeObjcSwizzlerClosure(format,
-                                       arguments);
+    return closure(format,
+                   arguments);
+}
+
+/// Returns the original Foundation formatting result for a format string and va_list.
+/// This bypasses swizzled parsing/translation and avoids variadic swizzle recursion.
+/// Safe to use as a fallback when we cannot parse the format specifiers reliably.
++ (instancetype)tx_originalLocalizedStringWithFormat:(NSString *)format
+                                              vaList:(va_list)args {
+    va_list argsCopy;
+    va_copy(argsCopy, args);
+
+    NSString *result = [[NSString alloc] initWithFormat:format
+                                                 locale:NSLocale.currentLocale
+                                              arguments:argsCopy];
+
+    va_end(argsCopy);
+    return result;
 }
 
 @end

--- a/Sources/TransifexObjCRuntime/include/TXNativeObjcSwizzler.h
+++ b/Sources/TransifexObjCRuntime/include/TXNativeObjcSwizzler.h
@@ -12,14 +12,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// The type of the extracted argument
 typedef NS_ENUM(NSInteger, TXNativeObjcArgumentType) {
-    TXNativeObjcArgumentTypeInvalid = -1,
     TXNativeObjcArgumentTypeInt,
     TXNativeObjcArgumentTypeUnsigned,
     TXNativeObjcArgumentTypeDouble,
     TXNativeObjcArgumentTypeChar,
     TXNativeObjcArgumentTypeCString,
-    TXNativeObjcArgumentTypeObject,
-    TXNativeObjcArgumentTypePercent
+    TXNativeObjcArgumentTypeObject
 };
 
 /// Wrapper class that contains the information about the extracted argument value and its type

--- a/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
+++ b/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
@@ -1,53 +1,34 @@
-//
-//  TXNativeObjcSwizzlerTests.m
-//  Transifex
-//
-//  Created by Stelios Petrakis on 16/11/20.
-//  Copyright © 2020 Transifex. All rights reserved.
-//
-
 #import <XCTest/XCTest.h>
 #import "TXNativeObjcSwizzler.h"
-@import Transifex;
 
-@interface MockLocaleProvider : NSObject <TXCurrentLocaleProvider>
-
-@property (nonatomic) NSString *mockLocaleCode;
-
-@end
-
-@implementation MockLocaleProvider
-
-- (instancetype)initWithMockLocaleCode:(NSString *)localeCode {
-    if (self = [super init]) {
-        self.mockLocaleCode = localeCode;
-    }
-
-    return self;
+static NSString *TXExpectedFormatted(NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    NSString *result = [[NSString alloc] initWithFormat:format
+                                                 locale:[NSLocale currentLocale]
+                                              arguments:args];
+    va_end(args);
+    return result;
 }
-
-- (NSString *)currentLocale {
-    return self.mockLocaleCode;
-}
-
-@end
 
 @interface TXNativeObjcSwizzlerTests : XCTestCase
 
-+ (NSString* (^)(NSString *format, NSArray <TXNativeObjcArgument *> *arguments)) closure;
++ (NSString* (^)(NSString *format,
+                 NSArray <TXNativeObjcArgument *> *arguments)) closure;
 
 @end
 
 @implementation TXNativeObjcSwizzlerTests
 
-+ (NSString* (^)(NSString *format, NSArray <TXNativeObjcArgument *> *arguments)) closure {
++ (NSString* (^)(NSString *format,
+                 NSArray <TXNativeObjcArgument *> *arguments)) closure {
     return ^NSString * (NSString *format,
                         NSArray<TXNativeObjcArgument *> * arguments) {
         NSMutableArray *argumentList = [NSMutableArray new];
         [arguments enumerateObjectsUsingBlock:^(TXNativeObjcArgument *obj,
                                                 NSUInteger idx,
                                                 BOOL *stop) {
-            [argumentList addObject:obj.value];
+            [argumentList addObject:obj.value ?: @"(null)"];
         }];
         NSString *args = [argumentList componentsJoinedByString:@","];
         return [NSString stringWithFormat:@"format: %@ arguments: %@",
@@ -56,83 +37,114 @@
     };
 }
 
-- (void)testOneInt {
++ (void)setUp {
     [TXNativeObjcSwizzler swizzleLocalizedStringWithClosure:self.class.closure];
+}
 
++ (void)tearDown {
+    [TXNativeObjcSwizzler revertLocalizedString];
+}
+
+- (void)testOneInt {
     NSString *finalString = [NSString localizedStringWithFormat:@"Test %d",
                              1];
     NSString *expectedString = @"format: Test %d arguments: 1";
 
     XCTAssertEqualObjects(finalString, expectedString);
-
-    [TXNativeObjcSwizzler revertLocalizedString];
 }
 
 - (void)testOneFloatOneString {
-    [TXNativeObjcSwizzler swizzleLocalizedStringWithClosure:self.class.closure];
-
     NSString *finalString = [NSString localizedStringWithFormat:@"Test %f %@",
                              3.14, @"Test"];
     NSString *expectedString = @"format: Test %f %@ arguments: 3.14,Test";
 
     XCTAssertEqualObjects(finalString, expectedString);
-
-    [TXNativeObjcSwizzler revertLocalizedString];
 }
 
-- (void)testAttributed API_AVAILABLE(macos(12.0), ios(15.0), watchos(8.0), tvos(15.0)) {
-    TXMemoryCache *memoryCache = [TXMemoryCache new];
-    [memoryCache updateWithTranslations:@{
-        @"en": @{
-            @"a": @{ @"string": @"a" }
-        },
-        @"el": @{
-            @"a": @{ @"string": @"α" }
-        },
-    }];
+- (void)testPercentLiteral {
+    NSString *finalString = [NSString localizedStringWithFormat:@"Test %% %@",
+                             @"ok"];
+    NSString *expectedString = @"format: Test %% %@ arguments: ok";
 
-    MockLocaleProvider *mockLocaleProvider = [MockLocaleProvider.alloc initWithMockLocaleCode:@"el"];
-
-    TXLocaleState *localeState = [TXLocaleState.alloc initWithSourceLocale:@"en"
-                                                                appLocales:@[ @"el" ]
-                                                     currentLocaleProvider:mockLocaleProvider];
-
-    [[[[TXNativeBuilder.new
-        setLocales:localeState]
-        setToken:@"<token>"]
-        setCache:memoryCache]
-        build];
-
-    NSString *string = [NSBundle.mainBundle localizedAttributedStringForKey:@"a"
-                                                                      value:nil
-                                                                      table:nil].string;
-    XCTAssertEqualObjects(string, @"α");
-
-    [TXNative dispose];
+    XCTAssertEqualObjects(finalString, expectedString);
 }
 
-- (void)testBuilder {
-    MockLocaleProvider *mockLocaleProvider = [MockLocaleProvider.alloc initWithMockLocaleCode:@"el"];
-    TXLocaleState *locales = [TXLocaleState.alloc initWithSourceLocale:@"en"
-                                                            appLocales:@[ @"el" ]
-                                                 currentLocaleProvider:mockLocaleProvider];
+- (void)testWidthPrecisionNoStar {
+    NSString *finalString = [NSString localizedStringWithFormat:@"Test %08.2f",
+                             3.14];
+    NSString *expectedString = @"format: Test %08.2f arguments: 3.14";
 
-    XCTAssertFalse([TXNativeBuilder.new build]);
+    XCTAssertEqualObjects(finalString, expectedString);
+}
 
-    XCTAssertFalse([[TXNativeBuilder.new
-                     setToken:@"token"]
-                     build]);
+- (void)testCStringInvalidUTF8 {
+    const char bytes[] = { (char)0xC3, (char)0x28, 0x00 };
+    const char *invalid = bytes;
+    NSString *finalString = [NSString localizedStringWithFormat:@"Test %s", invalid];
+    NSString *expectedString = @"format: Test %s arguments: (null)";
 
-    XCTAssertFalse([[TXNativeBuilder.new
-                     setLocales:locales]
-                     build]);
+    XCTAssertEqualObjects(finalString, expectedString);
+}
 
-    XCTAssertTrue([[[TXNativeBuilder.new
-                     setLocales:locales]
-                     setToken:@"token"]
-                     build]);
+- (void)testRejectsPositionalSpecifiers {
+    NSString *actual = [NSString localizedStringWithFormat:@"Test %1$@ %2$@", @"a", @"b"];
+    NSString *expected = TXExpectedFormatted(@"Test %1$@ %2$@", @"a", @"b");
 
-    [TXNative dispose];
+    XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRejectsWidthPrecisionWithStar {
+    NSString *actual = [NSString localizedStringWithFormat:@"Test %*.*f", 6, 2, 1.234];
+    NSString *expected = TXExpectedFormatted(@"Test %*.*f", 6, 2, 1.234);
+
+    XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRejectsLengthModifierLL {
+    long long value = 42;
+    NSString *actual = [NSString localizedStringWithFormat:@"Test %lld", value];
+    NSString *expected = TXExpectedFormatted(@"Test %lld", value);
+
+    XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRejectsLengthModifierZ {
+    size_t value = 42;
+    NSString *actual = [NSString localizedStringWithFormat:@"Test %zu", value];
+    NSString *expected = TXExpectedFormatted(@"Test %zu", value);
+
+    XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRejectsUnhandledConversionHex {
+    int value = 255;
+    NSString *actual = [NSString localizedStringWithFormat:@"Test %x", value];
+    NSString *expected = TXExpectedFormatted(@"Test %x", value);
+
+    XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRejectsUnhandledConversionPointer {
+    void *ptr = (void *)0x1234;
+    NSString *actual = [NSString localizedStringWithFormat:@"Test %p", ptr];
+    NSString *expected = TXExpectedFormatted(@"Test %p", ptr);
+
+    XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRejectsMixedSpecifiers {
+    NSString *actual = [NSString localizedStringWithFormat:@"%d %lld", 7, (long long)42];
+    NSString *expected = TXExpectedFormatted(@"%d %lld", 7, (long long)42);
+
+    XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRejectsLongDoubleL {
+    long double value = 3.14L;
+    NSString *actual = [NSString localizedStringWithFormat:@"Test %Lf", value];
+    NSString *expected = TXExpectedFormatted(@"Test %Lf", value);
+
+    XCTAssertEqualObjects(actual, expected);
 }
 
 @end

--- a/Tests/TransifexObjCTests/TXNativeObjcTests.m
+++ b/Tests/TransifexObjCTests/TXNativeObjcTests.m
@@ -1,0 +1,95 @@
+//
+//  TXNativeObjcTests.m
+//  Transifex
+//
+//  Created by Stelios Petrakis on 16/11/20.
+//  Copyright © 2020 Transifex. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+@import Transifex;
+
+@interface MockLocaleProvider : NSObject <TXCurrentLocaleProvider>
+
+@property (nonatomic) NSString *mockLocaleCode;
+
+@end
+
+@implementation MockLocaleProvider
+
+- (instancetype)initWithMockLocaleCode:(NSString *)localeCode {
+    if (self = [super init]) {
+        self.mockLocaleCode = localeCode;
+    }
+
+    return self;
+}
+
+- (NSString *)currentLocale {
+    return self.mockLocaleCode;
+}
+
+@end
+
+@interface TXNativeObjcTests : XCTestCase
+
+@end
+
+@implementation TXNativeObjcTests
+
+- (void)testAttributed API_AVAILABLE(macos(12.0), ios(15.0), watchos(8.0), tvos(15.0)) {
+    TXMemoryCache *memoryCache = [TXMemoryCache new];
+    [memoryCache updateWithTranslations:@{
+        @"en": @{
+            @"a": @{ @"string": @"a" }
+        },
+        @"el": @{
+            @"a": @{ @"string": @"α" }
+        },
+    }];
+
+    MockLocaleProvider *mockLocaleProvider = [MockLocaleProvider.alloc initWithMockLocaleCode:@"el"];
+
+    TXLocaleState *localeState = [TXLocaleState.alloc initWithSourceLocale:@"en"
+                                                                appLocales:@[ @"el" ]
+                                                     currentLocaleProvider:mockLocaleProvider];
+
+    [[[[TXNativeBuilder.new
+        setLocales:localeState]
+        setToken:@"<token>"]
+        setCache:memoryCache]
+        build];
+
+    NSString *string = [NSBundle.mainBundle localizedAttributedStringForKey:@"a"
+                                                                      value:nil
+                                                                      table:nil].string;
+    XCTAssertEqualObjects(string, @"α");
+
+    [TXNative dispose];
+}
+
+- (void)testBuilder {
+    MockLocaleProvider *mockLocaleProvider = [MockLocaleProvider.alloc initWithMockLocaleCode:@"el"];
+    TXLocaleState *locales = [TXLocaleState.alloc initWithSourceLocale:@"en"
+                                                            appLocales:@[ @"el" ]
+                                                 currentLocaleProvider:mockLocaleProvider];
+
+    XCTAssertFalse([TXNativeBuilder.new build]);
+
+    XCTAssertFalse([[TXNativeBuilder.new
+                     setToken:@"token"]
+                     build]);
+
+    XCTAssertFalse([[TXNativeBuilder.new
+                     setLocales:locales]
+                     build]);
+
+    XCTAssertTrue([[[TXNativeBuilder.new
+                     setLocales:locales]
+                     setToken:@"token"]
+                     build]);
+
+    [TXNative dispose];
+}
+
+@end


### PR DESCRIPTION
The implementation of the `swizzledLocalizedStringWithFormat:` method
could lead to crashes when the parsing the argument list encountered
unexpected characters (e.g. position arguments etc).

This commit refactors the logic of the method, making sure that it
parses the provided format string, matching strictly what is needed by
changing the regular expression and rejecting any other specifiers /
modifiers that are not supported, falling back to the original method
if swizzling is not possible.

A new suite of tests has been added that moves existing and new
Objective-C swizzling tests together, testing rejections as well.

Ref: #86

---

Bump version to 2.0.11

* Bumps version to 2.0.11.
* Updates CHANGELOG with the changes implemented for 2.0.11.