### PR TITLE
Swizzling crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,3 +191,12 @@ pattern.
 * Improves Objective-C swizzling method, ensuring it does not crash when parsing
 the argument list (`swizzledLocalizedStringWithFormat:`).
 * Adds more unit tests.
+
+## Transifex iOS SDK 2.0.12
+
+*March 6, 2026
+
+* Fix crash regression on swizzled method regarding stringsdict plural format
+specifier.
+* Improves swizzling logic.
+* Adds specialized unit test.

--- a/Sources/Transifex/Core.swift
+++ b/Sources/Transifex/Core.swift
@@ -450,7 +450,7 @@ render '\(stringToRender)' locale code: \(localeCode) params: \(params). Error:
 /// A static class that is the main point of entry for all the functionality of Transifex Native throughout the SDK.
 public final class TXNative : NSObject {
     /// The SDK version
-    internal static let version = "2.0.11"
+    internal static let version = "2.0.12"
     
     /// The filename of the file that holds the translated strings and it's bundled inside the app.
     public static let STRINGS_FILENAME = "txstrings.json"

--- a/Sources/TransifexObjCRuntime/TXNativeObjcSwizzler.m
+++ b/Sources/TransifexObjCRuntime/TXNativeObjcSwizzler.m
@@ -150,6 +150,14 @@ static NSString *(^TXNativeObjcSwizzlerClosure)(NSString *, NSArray <id> *);
             }
             // Objective-C object (%@)
             case '@': {
+                // %#@ is Apple's stringsdict plural variable specifier — its
+                // argument is a numeric count, not an ObjC object pointer.
+                // Reading it as `id` causes ARC to retain an invalid pointer,
+                // resulting in EXC_BAD_ACCESS. Fall back for any %#@ match.
+                if ([originalMatchString rangeOfString:@"#"].location != NSNotFound) {
+                    shouldFallback = YES;
+                    break;
+                }
                 id obj = va_arg(argumentList, id);
                 arg.value = obj;
                 arg.type = TXNativeObjcArgumentTypeObject;

--- a/Sources/TransifexObjCRuntime/TXNativeObjcSwizzler.m
+++ b/Sources/TransifexObjCRuntime/TXNativeObjcSwizzler.m
@@ -85,11 +85,7 @@ static NSString *(^TXNativeObjcSwizzlerClosure)(NSString *, NSArray <id> *);
             // Integer (%d, %i)
             case 'd': case 'i': {
                 // Reject length modifiers
-                if ([originalMatchString rangeOfString:@"h"].location != NSNotFound ||
-                    [originalMatchString rangeOfString:@"l"].location != NSNotFound ||
-                    [originalMatchString rangeOfString:@"j"].location != NSNotFound ||
-                    [originalMatchString rangeOfString:@"z"].location != NSNotFound ||
-                    [originalMatchString rangeOfString:@"t"].location != NSNotFound) {
+                if ([NSString tx_containsLengthModifier:originalMatchString]) {
                     shouldFallback = YES;
                     break;
                 }
@@ -101,11 +97,7 @@ static NSString *(^TXNativeObjcSwizzlerClosure)(NSString *, NSArray <id> *);
             // Unsigned (%u)
             case 'u': {
                 // Reject length modifiers
-                if ([originalMatchString rangeOfString:@"h"].location != NSNotFound ||
-                    [originalMatchString rangeOfString:@"l"].location != NSNotFound ||
-                    [originalMatchString rangeOfString:@"j"].location != NSNotFound ||
-                    [originalMatchString rangeOfString:@"z"].location != NSNotFound ||
-                    [originalMatchString rangeOfString:@"t"].location != NSNotFound) {
+                if ([NSString tx_containsLengthModifier:originalMatchString]) {
                     shouldFallback = YES;
                     break;
                 }
@@ -119,7 +111,7 @@ static NSString *(^TXNativeObjcSwizzlerClosure)(NSString *, NSArray <id> *);
             case 'g': case 'G':
             case 'a': case 'A':
             case 'f': case 'F': {
-                // Reject length modifiers except L (long double)
+                // Only fall back for L (long double)
                 if ([originalMatchString rangeOfString:@"L"].location != NSNotFound) {
                     shouldFallback = YES;
                     break;
@@ -150,7 +142,7 @@ static NSString *(^TXNativeObjcSwizzlerClosure)(NSString *, NSArray <id> *);
             }
             // Objective-C object (%@)
             case '@': {
-                // %#@ is Apple's stringsdict plural variable specifier — its
+                // %#@ is Apple's stringsdict plural variable specifier so its
                 // argument is a numeric count, not an ObjC object pointer.
                 // Reading it as `id` causes ARC to retain an invalid pointer,
                 // resulting in EXC_BAD_ACCESS. Fall back for any %#@ match.
@@ -212,6 +204,18 @@ static NSString *(^TXNativeObjcSwizzlerClosure)(NSString *, NSArray <id> *);
 
     va_end(argsCopy);
     return result;
+}
+
+#pragma mark - Helper
+
+/// Returns YES if the format specifier string contains a length modifier that changes the integer argument
+/// type away from plain int/unsigned int (i.e. h, hh, l, ll, j, z, t).
++ (BOOL)tx_containsLengthModifier:(NSString *)specifier {
+    return [specifier rangeOfString:@"h"].location != NSNotFound ||
+           [specifier rangeOfString:@"l"].location != NSNotFound ||
+           [specifier rangeOfString:@"j"].location != NSNotFound ||
+           [specifier rangeOfString:@"z"].location != NSNotFound ||
+           [specifier rangeOfString:@"t"].location != NSNotFound;
 }
 
 @end

--- a/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
+++ b/Tests/TransifexObjCTests/TXNativeObjcSwizzlerTests.m
@@ -147,4 +147,15 @@ static NSString *TXExpectedFormatted(NSString *format, ...) {
     XCTAssertEqualObjects(actual, expected);
 }
 
+- (void)testRejectsStringsdictPluralSpecifier {
+    // %#@varname@ is Apple's stringsdict plural variable specifier.
+    // Its argument is a numeric count, not an ObjC object. Reading it as `id`
+    // causes ARC to retain an invalid pointer (EXC_BAD_ACCESS). Must fall back.
+    NSUInteger count = 1;
+    NSString *actual = [NSString localizedStringWithFormat:@"%#@num_images@", count];
+    NSString *expected = TXExpectedFormatted(@"%#@num_images@", count);
+
+    XCTAssertEqualObjects(actual, expected);
+}
+
 @end


### PR DESCRIPTION
### Fix EXC_BAD_ACCESS crash for stringsdict plural format specifier

%#@varname@ is Apple's stringsdict plural variable specifier whose
argument is a numeric count, not an ObjC object pointer. The regex was
matching %#@ as a standard %@ (ObjC object), causing ARC to retain an
invalid pointer value and crash with EXC_BAD_ACCESS at a near-null address.

Fall back to the original implementation when the # flag is detected on
a % @ specifier, and add a regression test.

---

### Swizzling improvements

* Improves code comments.
* Refactors integer length modifier check into a helper method.

---

### Bump version to 2.0.12

* Bumps version to 2.0.12.
* Updates CHANGELOG with the changes implemented for 2.0.12.